### PR TITLE
HelpersTask49_Fix_bugs_in_helpers_2

### DIFF
--- a/dev_scripts_helpers/thin_client/setenv.sh
+++ b/dev_scripts_helpers/thin_client/setenv.sh
@@ -75,15 +75,22 @@ set_pythonpath
 
 if [[ $IS_SUPER_REPO == 1 ]]; then
     # Add helpers.
-    dassert_dir_exists $HELPERS_ROOT_DIR
-    export PYTHONPATH=$HELPERS_ROOT_DIR:$PYTHONPATH
+    # dassert_dir_exists $HELPERS_ROOT_DIR
+    # export PYTHONPATH=$HELPERS_ROOT_DIR:$PYTHONPATH
 
     # We need to give priority to the local `repo_config` over the one in
     # `helpers_root`.
-    export PYTHONPATH=$(pwd):$PYTHONPATH
+    # export PYTHONPATH=$(pwd):$PYTHONPATH
 
     # Remove duplicates.
-    export PYTHONPATH=$(remove_dups $PYTHONPATH)
+    # export PYTHONPATH=$(remove_dups $PYTHONPATH)
+
+    # TODO(*): Is there a better way to do this?
+    # Make sure current dir has the highest priority.
+    # For example, if we are in `cmamp/ck.infra`, we want to have
+    # `cmamp/ck.infra` at the top.
+    # We unset the path because we need to remove `cmamp` from the path as well.
+    export PROMPT_COMMAND='unset PYTHONPATH; export PYTHONPATH=$(pwd):$(remove_dups $HELPERS_ROOT_DIR:$PYTHONPATH)'
 
     # Print.
     echo "PYTHONPATH=$PYTHONPATH"


### PR DESCRIPTION
Task causify-ai/csfy#37


> * Do we need to copy the following files as well? It seems that I was able to run the build command without them. Or is it for running the `invoke` command from inside the container?
> 
> > cp /Users/saggese/src/cmamp2/changelog.txt .
> > cp /Users/saggese/src/cmamp2/invoke.yaml .
> > cp /Users/saggese/src/cmamp2/tasks.py .
> > cp /Users/saggese/src/cmamp2/{pytest.ini,conftest.py} .

I think we still need these. 
- The reason it was not raising an error is because after we activate the thin client with `source dev_scripts_cmamp/thin_client/setenv.sh`, the `cmamp` directory is always at the top of PYTHONPATH.
- Thus, the script that we use always use `cmamp` as reference rather than the `cmamp/ck.infra`

I think we need to dynamically update the PYTHONPATH when we change to a sub directory:
```bash
(client_venv.cmamp) heanhs@dev1:~/src/cmamp3$ python -c "import sys; print('\n'.join(sys.path))"

/data/heanhs/src/cmamp3
/data/heanhs/src/cmamp3/helpers_root
...
(client_venv.cmamp) heanhs@dev1:~/src/cmamp3$ cd ck.infra/
(client_venv.cmamp) heanhs@dev1:~/src/cmamp3/ck.infra$ python -c "import sys; print('\n'.join(sys.path))"

/data/heanhs/src/cmamp3/ck.infra
/data/heanhs/src/cmamp3/helpers_root
...
```