### PR TITLE
HelpersTask69_Fix_file_path_issue_in_helpers

### DIFF
--- a/helpers/hgit.py
+++ b/helpers/hgit.py
@@ -709,7 +709,7 @@ def find_file_in_git_tree(
     root_dir = get_client_root(super_module=super_module)
     cmd = rf"find {root_dir} -name '{file_name}' -not -path '*/.git/*'"
     if remove_tmp_base:
-        cmd += rf"-not -path '*/tmp\.base/*'"
+        cmd += rf" -not -path '*/tmp\.base/*'"
     _, file_name = hsystem.system_to_one_line(cmd)
     _LOG.debug("file_name=%s", file_name)
     hdbg.dassert_ne(


### PR DESCRIPTION
FYI @PomazkinG @samarth9008 the power of single whitespace :D 
without the whitespace the command is not rendered correctly and yields unexpected results, there has to be a whitespace before `-not ...` 