### PR TITLE
CmampTask10772_Revert_pytest.ini_changes_exclude_notebooks_folder

### DIFF
--- a/helpers/test/test_master_buildmeister_dashboard.py
+++ b/helpers/test/test_master_buildmeister_dashboard.py
@@ -35,5 +35,5 @@ class Test_Master_buildmeister_dashboard_notebook(
         notebook_path = os.path.join(
             amp_dir, "devops", "notebooks", "Master_buildmeister_dashboard.ipynb"
         )
-        config_builder = "helpers.notebooks.test.test_master_buildmeister_dashboard.build_config()"
+        config_builder = "helpers.test.test_master_buildmeister_dashboard.build_config()"
         self._test_run_notebook(notebook_path, config_builder)

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ norecursedirs =
   dev_scripts/old
   helpers/old
   im/ib/data/extract/gateway
+  notebooks  
 
 #ignore = .git im/ib/data/extract/gateway
 #ignore-glob = notebooks* old/*


### PR DESCRIPTION
[#10772](https://github.com/cryptokaizen/cmamp/issues/10772)

- move test `helpers/notebooks/test/test_master_buildmeister_dashboard.py` -> `helpers/test/test_master_buildmeister_dashboard.py`
- revert changes in the `pytest.ini`