### PR TITLE
CmTask10909: fix c8 reconciliation tests

### DIFF
--- a/helpers/hdbg.py
+++ b/helpers/hdbg.py
@@ -802,7 +802,7 @@ def dassert_dir_exists(
     Assert unless `dir_name` exists and it's a directory.
     """
     dassert_isinstance(dir_name, str)
-    if dir_name is not hs3.is_s3_path(dir_name):
+    if not hs3.is_s3_path(dir_name):
         # No need to normalize S3 paths, they are already absolutized.
         dir_name = os.path.abspath(dir_name)
     # `dir_name` exists.


### PR DESCRIPTION
part of https://github.com/causify-ai/orange/pull/662

Not process s3 paths with `os.path.abspath(dir_name)` in `dassert_dir_exists`


The problem is `test_save_data_for_short_reconciliation_test` fails because in `dassert_dir_exists` s3 path `s3://cryptokaizen-unit-test/outcomes/Test_C8b_ProdReconciliation.test_save_data_for_short_reconciliation_test/input` is transformed to `/app/s3:/cryptokaizen-unit-test/outcomes/Test_C8b_ProdReconciliation.test_save_data_for_short_reconciliation_test/input` through os.path.abspath(dir_name)

```python
  File "/app/dataflow_lemonade/system/C8/test/test_C8b_reconciliation.py", line 10, in test_save_data_for_short_reconciliation_test
    self._save_data_for_reconciliation_test(
  File "/app/amp/dataflow_amp/system/Cx/Cx_reconciliation_test_case.py", line 209, in _save_data_for_reconciliation_test
    dtfasycxut.dump_market_data_from_db(
  File "/app/amp/dataflow_amp/system/Cx/utils.py", line 375, in dump_market_data_from_db
    hdbg.dassert_dir_exists(dst_dir)
  File "/app/amp/helpers_root/helpers/hdbg.py", line 808, in dassert_dir_exists
    _dfatal(txt, msg, *args, only_warning=only_warning)
  File "/app/amp/helpers_root/helpers/hdbg.py", line 142, in _dfatal
    dfatal(dfatal_txt)
  File "/app/amp/helpers_root/helpers/hdbg.py", line 71, in dfatal
    raise assertion_type(ret)
AssertionError:
################################################################################
* Failed assertion *
Dir '/app/s3:/cryptokaizen-unit-test/outcomes/Test_C8b_ProdReconciliation.test_save_data_for_short_reconciliation_test/input' doesn't exist
################################################################################```