### PR TITLE
CmampTask10898_Rename_remove_env_vars_in_all_repos_2

### DIFF
--- a/helpers/test/test_repo_config_amp.py
+++ b/helpers/test/test_repo_config_amp.py
@@ -259,8 +259,8 @@ class TestRepoConfig_Amp_signature1(hunitest.TestCase):
           AM_FORCE_TEST_FAIL=''
           AM_REPO_CONFIG_CHECK='True'
           AM_REPO_CONFIG_PATH=''
-          CSFY_CI='true'
           CK_ECR_BASE_PATH='$CK_ECR_BASE_PATH'
+          CSFY_CI='true'
         """
         # We ignore the AWS vars, since GH Actions does some replacement to mask
         # the env vars coming from secrets.


### PR DESCRIPTION

Follow-up from https://github.com/causify-ai/helpers/pull/122
The failure manifested only after merging since the test runs on cmamp only