### PR TITLE
CmTask11001_Build_fail_cmamp_airflow_fastslowsuperslow_tests_12286911507_

### DIFF
--- a/helpers/test/test_lib_tasks.py
+++ b/helpers/test/test_lib_tasks.py
@@ -330,7 +330,6 @@ class TestDryRunTasks2(_LibTasksTestCase, _CheckDryRunTestCase):
     # TODO(Shaopengz): Outside CK infra, the test hangs, so skip.
     @pytest.mark.requires_ck_infra
     @pytest.mark.skipif(not hgit.is_amp(), reason="Only run in amp")
-    @pytest.mark.skip(reason="Skiping run in CmampTask11001")
     def test_gh_workflow_list(self) -> None:
         target = "gh_workflow_list(ctx, filter_by_branch='master')"
         self._check_output(target)


### PR DESCRIPTION
[#11001
](https://github.com/causify-ai/csfy/issues/5343)
- Enable the test case `test_gh_workflow_list`

fyi @dremdem @sonaalKant @PomazkinG 