### PR TITLE
DevToolsTask607: Add the arg for using dockerized prettier

### DIFF
--- a/dev_scripts_helpers/documentation/lint_notes.py
+++ b/dev_scripts_helpers/documentation/lint_notes.py
@@ -383,6 +383,10 @@ def _parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
     )
+    parser.add_argument(
+         "--use_dockerized_prettier",
+        action="store_false",
+    )
     hparser.add_action_arg(parser, _VALID_ACTIONS, _DEFAULT_ACTIONS)
     hparser.add_verbosity_arg(parser)
     return parser
@@ -405,7 +409,11 @@ def _main(args: argparse.Namespace) -> None:
     txt = args.infile.read()
     # Process.
     txt = _process(
-        txt, in_file_name, actions=args.action, print_width=args.print_width
+        txt, 
+        in_file_name, 
+        actions=args.action, 
+        print_width=args.print_width,
+        use_dockerized_prettier=args.use_dockerized_prettier,
     )
     # Write output.
     if args.in_place:


### PR DESCRIPTION
For fixing https://github.com/causify-ai/dev_tools/issues/607: adding an argument to control whether to use dockerized prettier or prettier installed locally