### PR TITLE
CmampTask11418_Release_multi_arch_version_helpers_linter_container2

### DIFF
--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -808,7 +808,10 @@ def docker_tag_push_multi_arch_prod_image(  # type: ignore
             f"Invalid target Docker image registry='{target_registry}'"
         )
     # Tag and push the versioned prod image as prod image.
-    image_prod = hlitadoc.get_image(prod_base_image, "prod")
+    latest_version = None
+    image_prod = hlitadoc.get_image(
+        prod_base_image, "prod", version=latest_version
+    )
     cmd = (
         f"docker buildx imagetools create -t {image_prod} {image_versioned_prod}"
     )

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -706,7 +706,6 @@ def docker_multi_build_prod_image(  # type: ignore
     dockerfile = "devops/docker_build/prod.Dockerfile"
     dockerfile = _to_abs_path(dockerfile)
     #
-    # TODO(gp): Use to_multi_line_cmd()
     opts = "--no-cache" if not cache else ""
     # Use dev version for building prod image.
     dev_version = hlitadoc.to_dev_version(prod_version)

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -665,8 +665,8 @@ def docker_multi_build_prod_image(  # type: ignore
         where hash is the output of `hgit.get_head_hash()`
     :param user_tag: the name of the user building the candidate image
     :param container_dir_name: directory where the Dockerfile is located
-    :param multi_arch: comma separated list of target architectures to build
-        the image for. E.g., `linux/amd64,linux/arm64`
+    :param multi_arch: comma separated list of target architectures to
+        build the image for. E.g., `linux/amd64,linux/arm64`
     """
     hlitauti.report_task(container_dir_name=container_dir_name)
     prod_version = hlitadoc.resolve_version_value(
@@ -735,7 +735,7 @@ def docker_multi_build_prod_image(  # type: ignore
     # Build.
     # Compress the current directory (in order to dereference symbolic
     # links) into a tar stream and pipes it to the `docker build` command.
-    # See HelpersTask197.    
+    # See HelpersTask197.
     cmd = rf"""
     tar -czh . | DOCKER_BUILDKIT={DOCKER_BUILDKIT} \
         time \
@@ -753,7 +753,7 @@ def docker_multi_build_prod_image(  # type: ignore
     cmd = rf"""
     docker pull {image_versioned_prod}
     """
-    hlitauti.run(ctx, cmd)    
+    hlitauti.run(ctx, cmd)
     if candidate:
         _LOG.info("Head hash: %s", head_hash)
     cmd = f"docker image ls {image_versioned_prod}"

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -21,6 +21,7 @@ import helpers.hsystem as hsystem
 import helpers.lib_tasks_docker as hlitadoc
 import helpers.lib_tasks_pytest as hlitapyt
 import helpers.lib_tasks_utils as hlitauti
+import repo_config as rconf
 
 _DEFAULT_TARGET_REGISTRY = "aws_ecr.ck"
 _LOG = logging.getLogger(__name__)

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -435,7 +435,7 @@ def docker_tag_push_multi_build_local_image_as_dev(  # type: ignore
         # Use AWS Docker registry.
         dev_base_image = ""
     elif target_registry == "dockerhub.causify":
-        # Use public GitHub Docker registry.
+        # Use public DockerHub registry.
         base_image_name = henv.execute_repo_config_code(
             "get_docker_base_image_name()"
         )

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -872,6 +872,7 @@ def docker_push_prod_candidate_image(  # type: ignore
 
 @task
 # TODO(Vlad): Add the release flow with the multi-arch support.
+# See HelpersTask339.
 def docker_release_prod_image(  # type: ignore
     ctx,
     version,

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -643,7 +643,7 @@ def docker_build_prod_image(  # type: ignore
 
 # TODO(gp): Remove redundancy with docker_build_local_image(), if possible.
 @task
-def docker_multi_build_prod_image(  # type: ignore
+def docker_build_multi_arch_prod_image(  # type: ignore
     ctx,
     version,
     cache=True,
@@ -726,12 +726,6 @@ def docker_multi_build_prod_image(  # type: ignore
     opts = "--no-cache" if not cache else ""
     # Use dev version for building prod image.
     dev_version = hlitadoc.to_dev_version(prod_version)
-    build_args = [
-        f"\n   VERSION={dev_version}",
-        f"\n   ECR_BASE_PATH={os.environ['CSFY_ECR_BASE_PATH']}",
-    ]
-    #
-    build_args = f"--build-arg {hlitauti.to_multi_line_cmd(build_args)}"
     # Build.
     # Compress the current directory (in order to dereference symbolic
     # links) into a tar stream and pipes it to the `docker build` command.
@@ -743,7 +737,8 @@ def docker_multi_build_prod_image(  # type: ignore
         {opts} \
         --push \
         --platform {multi_arch} \
-        {build_args} \
+        --build-arg VERSION={dev_version} \
+        --build-arg ECR_BASE_PATH={os.environ['CSFY_ECR_BASE_PATH']} \
         --tag {image_versioned_prod} \
         --file {dockerfile} \
         -
@@ -761,8 +756,9 @@ def docker_multi_build_prod_image(  # type: ignore
 
 
 # TODO(Vlad): Refactor with the `docker_tag_push_multi_build_local_image_as_dev()`.
+# TODO(Vlad): Add the candidate image support. See HelpersTask338.
 @task
-def docker_multi_build_push_tag_prod_image(  # type: ignore
+def docker_multi_arch_push_tag_prod_image(  # type: ignore
     ctx,
     version,
     base_image="",
@@ -875,6 +871,7 @@ def docker_push_prod_candidate_image(  # type: ignore
 
 
 @task
+# TODO(Vlad): Add the release flow with the multi-arch support.
 def docker_release_prod_image(  # type: ignore
     ctx,
     version,

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -677,9 +677,7 @@ def docker_build_multi_arch_prod_image(  # type: ignore
     # TODO(gp): We should do a `i git_clean` to remove artifacts and check that
     #  the client is clean so that we don't release from a dirty client.
     # Build prod image.
-    image_versioned_prod = hlitadoc.get_image(
-        base_image, "prod", prod_version
-    )
+    image_versioned_prod = hlitadoc.get_image(base_image, "prod", prod_version)
     hlitadoc.dassert_is_image_name_valid(image_versioned_prod)
     # Login to AWS ECR because for multi-arch build the image is built locally
     # and pushed to the remote registry automatically.
@@ -766,7 +764,9 @@ def docker_tag_push_multi_arch_prod_image(  # type: ignore
     prod_version = hlitadoc.resolve_version_value(
         version, container_dir_name=container_dir_name
     )
-    aws_image_versioned_prod = hlitadoc.get_image(base_image, "prod", prod_version)
+    aws_image_versioned_prod = hlitadoc.get_image(
+        base_image, "prod", prod_version
+    )
     _LOG.info(
         "Pushing the prod image %s to the target_registry %s",
         aws_image_versioned_prod,
@@ -789,7 +789,7 @@ def docker_tag_push_multi_arch_prod_image(  # type: ignore
         docker buildx imagetools create \
             -t {dockerhub_image_versioned_prod} {aws_image_versioned_prod}
         """
-        hlitauti.run(ctx, cmd)        
+        hlitauti.run(ctx, cmd)
     else:
         raise ValueError(
             f"Invalid target Docker image registry='{target_registry}'"

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -562,7 +562,7 @@ def docker_build_prod_image(  # type: ignore
     user_tag="",
     container_dir_name=".",
     tag=None,
-    multi_arch=None,    
+    multi_arch=None,
 ):
     """
     Build a prod image from a dev image.
@@ -578,7 +578,7 @@ def docker_build_prod_image(  # type: ignore
     :param multi_arch:
         - if not specified, build for the current architecture
         - if specified, build for the specified multiple architectures. E.g.,
-          `linux/amd64,linux/arm64`        
+          `linux/amd64,linux/arm64`
     """
     hlitauti.report_task(container_dir_name=container_dir_name)
     prod_version = hlitadoc.resolve_version_value(
@@ -631,7 +631,7 @@ def docker_build_prod_image(  # type: ignore
             ("POETRY_MODE", "no_update"),
             ("CLEAN_UP_INSTALLATION", True),
         ]
-        build_args = " ".join("--build-arg %s=%s" % (k, v) for k, v in build_args)        
+        build_args = " ".join("--build-arg %s=%s" % (k, v) for k, v in build_args)
         # Login to AWS ECR because for multi-arch we need to build the local
         # image remotely.
         hlitadoc.docker_login(ctx)
@@ -668,7 +668,7 @@ def docker_build_prod_image(  # type: ignore
             --file {dockerfile} \
             -
         """
-        hlitauti.run(ctx, cmd)     
+        hlitauti.run(ctx, cmd)
     else:
         cmd = rf"""
         DOCKER_BUILDKIT={DOCKER_BUILDKIT} \
@@ -681,7 +681,7 @@ def docker_build_prod_image(  # type: ignore
             --build-arg ECR_BASE_PATH={os.environ["CSFY_ECR_BASE_PATH"]} \
             .
         """
-        hlitauti.run(ctx, cmd)    
+        hlitauti.run(ctx, cmd)
     if candidate:
         _LOG.info("Head hash: %s", head_hash)
         cmd = f"docker image ls {image_versioned_prod}"
@@ -746,7 +746,9 @@ def docker_multi_build_push_tag_prod_image(  # type: ignore
         )
     # Tag and push the versioned prod image as prod image.
     image_prod = hlitadoc.get_image(prod_base_image, "prod")
-    cmd = f"docker buildx imagetools create -t {image_prod} {image_versioned_prod}"
+    cmd = (
+        f"docker buildx imagetools create -t {image_prod} {image_versioned_prod}"
+    )
     hlitauti.run(ctx, cmd)
 
 

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -760,7 +760,7 @@ def docker_build_multi_arch_prod_image(  # type: ignore
 # TODO(Vlad): Refactor with the `docker_tag_push_multi_build_local_image_as_dev()`.
 # TODO(Vlad): Add the candidate image support. See HelpersTask338.
 @task
-def docker_multi_arch_push_tag_prod_image(  # type: ignore
+def docker_tag_push_multi_arch_prod_image(  # type: ignore
     ctx,
     version,
     base_image="",

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -655,9 +655,9 @@ def docker_build_multi_arch_prod_image(  # type: ignore
     multi_arch="linux/amd64,linux/arm64",
 ):
     """
-    Build a multi arch. versioned prod image from a dev image.
-        For e.g.: we have the dev image `helpers:dev-1.0.0` and we want to
-        build a prod image `helpers:prod-1.0.0`.
+    Build a multi arch. versioned prod image from a dev image. For e.g.: we
+    have the dev image `helpers:dev-1.0.0` and we want to build a prod image
+    `helpers:prod-1.0.0`.
 
     :param version: version to tag the image and code with
     :param cache: note that often the prod image is just a copy of the

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -701,7 +701,9 @@ def docker_build_multi_arch_prod_image(  # type: ignore
     hlitauti.run(ctx, cmd)
     # Prepare the build.
     dockerfile = "devops/docker_build/prod.Dockerfile"
-    dockerfile = _to_abs_path(dockerfile)
+    # Keep the relative path instead of an absolute path to ensure it matches
+    # files inside the tar stream and avoids file not found errors.    
+    # dockerfile = _to_abs_path(dockerfile)
     #
     opts = "--no-cache" if not cache else ""
     # Use dev version for building prod image.

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -710,7 +710,6 @@ def docker_multi_build_prod_image(  # type: ignore
     # Use dev version for building prod image.
     dev_version = hlitadoc.to_dev_version(prod_version)
     build_args = [
-        opts,
         f"\n   VERSION={dev_version}",
         f"\n   ECR_BASE_PATH={os.environ['CSFY_ECR_BASE_PATH']}",
     ]

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -781,21 +781,19 @@ def docker_tag_push_multi_arch_prod_image(  # type: ignore
             "get_docker_base_image_name()"
         )
         prod_base_image = f"causify/{base_image_name}"
-    else:
-        raise ValueError(
-            f"Invalid target Docker image registry='{target_registry}'"
-        )
-    # Tag and push the versioned prod image. The versioned prod image is
-    # already built in the AWS ECR registry.
-    if target_registry != "aws_ecr.ck":
-        target_image_versioned_prod = hlitadoc.get_image(
+        # Tag and push the versioned prod image.
+        dockerhub_image_versioned_prod = hlitadoc.get_image(
             prod_base_image, "prod", prod_version
         )
         cmd = rf"""
         docker buildx imagetools create \
-            -t {target_image_versioned_prod} {aws_image_versioned_prod}
+            -t {dockerhub_image_versioned_prod} {aws_image_versioned_prod}
         """
-        hlitauti.run(ctx, cmd)
+        hlitauti.run(ctx, cmd)        
+    else:
+        raise ValueError(
+            f"Invalid target Docker image registry='{target_registry}'"
+        )
     # Tag and push the versioned prod image as prod image.
     latest_version = None
     image_prod = hlitadoc.get_image(

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -652,7 +652,7 @@ def docker_multi_build_prod_image(  # type: ignore
     user_tag="",
     container_dir_name=".",
     tag=None,
-    multi_arch=None,
+    multi_arch="linux/amd64,linux/arm64",
 ):
     """
     Build a multi arch. prod image from a dev image.
@@ -665,12 +665,9 @@ def docker_multi_build_prod_image(  # type: ignore
         where hash is the output of `hgit.get_head_hash()`
     :param user_tag: the name of the user building the candidate image
     :param container_dir_name: directory where the Dockerfile is located
-    :param multi_arch:
-        - if not specified, build for the `linux/amd64,linux/arm64`
-        - if specified, build for the specified multiple architectures.
+    :param multi_arch: comma separated list of target architectures to build
+        the image for. E.g., `linux/amd64,linux/arm64`
     """
-    if multi_arch is None:
-        multi_arch = "linux/amd64,linux/arm64"
     hlitauti.report_task(container_dir_name=container_dir_name)
     prod_version = hlitadoc.resolve_version_value(
         version, container_dir_name=container_dir_name
@@ -702,18 +699,6 @@ def docker_multi_build_prod_image(  # type: ignore
             base_image, "prod", prod_version
         )
     hlitadoc.dassert_is_image_name_valid(image_versioned_prod)
-    #
-    dockerfile = "devops/docker_build/prod.Dockerfile"
-    dockerfile = _to_abs_path(dockerfile)
-    #
-    opts = "--no-cache" if not cache else ""
-    # Use dev version for building prod image.
-    dev_version = hlitadoc.to_dev_version(prod_version)
-    build_args = [
-        f"\n   VERSION={dev_version}",
-        f"\n   ECR_BASE_PATH={os.environ['CSFY_ECR_BASE_PATH']}",
-    ]
-    build_args = f"--build-arg {hlitauti.to_multi_line_cmd(build_args)}"
     # Login to AWS ECR because for multi-arch build the image is built locally
     # and pushed to the remote registry automatically.
     hlitadoc.docker_login(ctx)
@@ -734,10 +719,23 @@ def docker_multi_build_prod_image(  # type: ignore
         docker buildx use {platform_builder}
     """
     hlitauti.run(ctx, cmd)
+    # Prepare the build.
+    dockerfile = "devops/docker_build/prod.Dockerfile"
+    dockerfile = _to_abs_path(dockerfile)
+    #
+    opts = "--no-cache" if not cache else ""
+    # Use dev version for building prod image.
+    dev_version = hlitadoc.to_dev_version(prod_version)
+    build_args = [
+        f"\n   VERSION={dev_version}",
+        f"\n   ECR_BASE_PATH={os.environ['CSFY_ECR_BASE_PATH']}",
+    ]
+    #
+    build_args = f"--build-arg {hlitauti.to_multi_line_cmd(build_args)}"
     # Build.
     # Compress the current directory (in order to dereference symbolic
     # links) into a tar stream and pipes it to the `docker build` command.
-    # See HelpersTask197.
+    # See HelpersTask197.    
     cmd = rf"""
     tar -czh . | DOCKER_BUILDKIT={DOCKER_BUILDKIT} \
         time \

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -655,7 +655,9 @@ def docker_build_multi_arch_prod_image(  # type: ignore
     multi_arch="linux/amd64,linux/arm64",
 ):
     """
-    Build a multi arch. prod image from a dev image.
+    Build a multi arch. versioned prod image from a dev image.
+        For e.g.: we have the dev image `helpers:dev-1.0.0` and we want to
+        build a prod image `helpers:prod-1.0.0`.
 
     :param version: version to tag the image and code with
     :param cache: note that often the prod image is just a copy of the

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -702,7 +702,7 @@ def docker_build_multi_arch_prod_image(  # type: ignore
     # Prepare the build.
     dockerfile = "devops/docker_build/prod.Dockerfile"
     # Keep the relative path instead of an absolute path to ensure it matches
-    # files inside the tar stream and avoids file not found errors.    
+    # files inside the tar stream and avoids file not found errors.
     # dockerfile = _to_abs_path(dockerfile)
     #
     opts = "--no-cache" if not cache else ""

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -773,9 +773,7 @@ def docker_multi_build_push_tag_prod_image(  # type: ignore
     Mark the multi-arch versioned "prod" image as "prod" and push it.
 
     `base_image` and `target_registry` both contain information about the target
-    Docker registry. Docker image registry address in `local_base_image` name
-    is ignored when pushing, instead the `target_registry` param provides a
-    Docker image registry address to push to.
+    Docker registry.
 
     :param ctx: invoke context
     :param version: version to tag the image and code with

--- a/helpers/lib_tasks_docker_release.py
+++ b/helpers/lib_tasks_docker_release.py
@@ -21,7 +21,6 @@ import helpers.hsystem as hsystem
 import helpers.lib_tasks_docker as hlitadoc
 import helpers.lib_tasks_pytest as hlitapyt
 import helpers.lib_tasks_utils as hlitauti
-import repo_config as rconf
 
 _DEFAULT_TARGET_REGISTRY = "aws_ecr.ck"
 _LOG = logging.getLogger(__name__)

--- a/tasks.py
+++ b/tasks.py
@@ -15,6 +15,7 @@ from helpers.lib_tasks import (  # This is not an invoke target.
 from helpers.lib_tasks import (  # isort: skip # noqa: F401  # pylint: disable=unused-import
     docker_bash,
     docker_build_local_image,
+    docker_build_multi_arch_prod_image,
     docker_build_prod_image,
     docker_cmd,
     docker_create_candidate_image,
@@ -35,6 +36,7 @@ from helpers.lib_tasks import (  # isort: skip # noqa: F401  # pylint: disable=u
     docker_rollback_prod_image,
     docker_stats,
     docker_tag_local_image_as_dev,  # TODO(gp): -> docker_release_...
+    docker_tag_push_multi_arch_prod_image,
     docker_update_prod_task_definition,
     find,
     find_check_string_output,


### PR DESCRIPTION
[#11418](https://github.com/causify-ai/cmamp/issues/11418)

- modify the docker_build_prod_image() to include multi-arch param
- make docker_multi_build_push_tag_prod_image()
