### PR TITLE
HelpersTask296: Add workaround for files that cannot be read

### DIFF
--- a/linters/amp_check_merge_conflict.py
+++ b/linters/amp_check_merge_conflict.py
@@ -34,6 +34,11 @@ def _check_merge_conflict(file_name: str, line_num: int, line: str) -> str:
     return msg
 
 
+# #############################################################################
+# _CheckMergeConflict
+# #############################################################################
+
+
 class _CheckMergeConflict(liaction.Action):
     """
     Check if there is a git merge conflict marker in the file.
@@ -44,8 +49,12 @@ class _CheckMergeConflict(liaction.Action):
 
     def _execute(self, file_name: str, pedantic: int) -> List[str]:
         _ = pedantic
-        # Read the input file.
-        lines = hio.from_file(file_name).split("\n")
+        try:
+            # Read the input file.
+            lines = hio.from_file(file_name).split("\n")
+        except RuntimeError:
+            _LOG.debug("Cannot read file_name='%s'; skipping", file_name)
+            return []
         output = []
         # Check the file lines for merge conflict markers.
         for i, line in enumerate(lines):

--- a/linters/amp_fix_comments.py
+++ b/linters/amp_fix_comments.py
@@ -29,6 +29,11 @@ import linters.utils as liutils
 _LOG = logging.getLogger(__name__)
 
 
+# #############################################################################
+# _LinesWithComment
+# #############################################################################
+
+
 @dataclasses.dataclass
 class _LinesWithComment:
     start_line: int
@@ -216,6 +221,11 @@ def _fix_comment_style(lines: List[str]) -> List[str]:
     return _replace_comments_in_lines(lines, comments)
 
 
+# #############################################################################
+# _FixComment
+# #############################################################################
+
+
 class _FixComment(liaction.Action):
     """
     Reflow, capitalize and add punctuation to comments.
@@ -228,7 +238,7 @@ class _FixComment(liaction.Action):
         _ = pedantic
         if not liutils.is_py_file(file_name):
             _LOG.debug("Skipping file_name='%s'", file_name)
-
+            return []
         lines = hio.from_file(file_name).split("\n")
         updated_lines = _reflow_comments_in_lines(lines)
         updated_lines = _fix_comment_style(updated_lines)

--- a/linters/amp_fix_whitespaces.py
+++ b/linters/amp_fix_whitespaces.py
@@ -65,6 +65,11 @@ def _format_end_of_file(lines: List[str]) -> List[str]:
     return lines_end_formatted
 
 
+# #############################################################################
+# _FixWhitespaces
+# #############################################################################
+
+
 class _FixWhitespaces(liaction.Action):
     """
     Fix irregularities with whitespace characters.
@@ -79,8 +84,12 @@ class _FixWhitespaces(liaction.Action):
 
     def _execute(self, file_name: str, pedantic: int) -> List[str]:
         _ = pedantic
-        # Read the input file.
-        lines = hio.from_file(file_name).split("\n")
+        try:
+            # Read the input file.
+            lines = hio.from_file(file_name).split("\n")
+        except RuntimeError:
+            _LOG.debug("Cannot read file_name='%s'; skipping", file_name)
+            return []
         updated_lines = []
         # Process the lines.
         for line in lines:


### PR DESCRIPTION
#296 Fix the bug that appeared when Linter encountered non-txt-based files (e.g. png)