### PR TITLE
Helpers task377 error in setting up thin client on local

### DIFF
--- a/dev_scripts_helpers/thin_client/build.py
+++ b/dev_scripts_helpers/thin_client/build.py
@@ -76,6 +76,8 @@ def _main(parser: argparse.ArgumentParser) -> None:
     if platform.system() == "Darwin" or (
         platform.system() == "Linux" and not hserver.is_dev_ck()
     ):
+        # Pinning down the package version for running locally on Mac and Linux,
+        # see HelpersTask377.
         with open(tmp_requirements_path, "a") as f:
             f.write("pyyaml == 5.3.1\n")
     _system(f"{activate_cmd} && python3 -m pip install --upgrade pip")

--- a/dev_scripts_helpers/thin_client/build.py
+++ b/dev_scripts_helpers/thin_client/build.py
@@ -15,6 +15,7 @@ import thin_client_utils as tcu
 import helpers.hdbg as hdbg
 import helpers.hparser as hparser
 import helpers.hprint as hprint
+import helpers.hserver as hserver
 import helpers.hsystem as hsystem
 
 _LOG = logging.getLogger(__name__)
@@ -72,7 +73,9 @@ def _main(parser: argparse.ArgumentParser) -> None:
     requirements_path = os.path.join(thin_environ_dir, "requirements.txt")
     tmp_requirements_path = os.path.join(thin_environ_dir, "tmp.requirements.txt")
     shutil.copy(requirements_path, tmp_requirements_path)
-    if platform.system() == "Darwin":
+    if platform.system() == "Darwin" or (
+        platform.system() == "Linux" and not hserver.is_dev_ck()
+    ):
         with open(tmp_requirements_path, "a") as f:
             f.write("pyyaml == 5.3.1\n")
     _system(f"{activate_cmd} && python3 -m pip install --upgrade pip")

--- a/dev_scripts_helpers/thin_client/requirements.txt
+++ b/dev_scripts_helpers/thin_client/requirements.txt
@@ -11,6 +11,6 @@ poetry
 pytest >= 6.0.0
 s3fs  # For tools like `publish_notebook.py`.
 tqdm
-# On Mac there is an issue related to this package, so you might want to pin it
-# down.
+# On Mac and locally on Linux there is an issue related to this package
+# (see HelpersTask377), so we might want to pin it down.
 # pyyaml == 5.3.1

--- a/docs/onboarding/intern.set_up_development_on_laptop.how_to_guide.md
+++ b/docs/onboarding/intern.set_up_development_on_laptop.how_to_guide.md
@@ -307,6 +307,14 @@
   - pull the latest container with `invoke docker_pull`
   ```
 
+- If you are prompted to enter sudo password, do not enter anything and press
+  Ctrl-C to resolve
+
+  ```bash
+  WARN  hserver.py _raise_invalid_host:342   Don't recognize host: host_os_name=Linux, am_host_os_name=None
+  [sudo] password for ubuntu:
+  ```
+
 - Start a Jupyter server
 
   ```bash

--- a/helpers/hserver.py
+++ b/helpers/hserver.py
@@ -159,6 +159,19 @@ def is_mac(*, version: Optional[str] = None) -> bool:
     return is_mac_
 
 
+def is_external_linux() -> bool:
+    """
+    Detect whether we are running on a non-server Linux machine.
+
+    :return: whether an external Linux system is running
+    """
+    host_os_name = os.uname()[0]
+    if host_os_name == "Linux" and not is_dev_ck():
+        # Running a Linux system but not on a dev server.
+        return True
+    return False
+
+
 def is_cmamp_prod() -> bool:
     """
     Detect whether we are running in a CK production container.
@@ -228,6 +241,7 @@ def _dassert_setup_consistency() -> None:
     is_ig_prod_ = is_ig_prod()
     is_inside_ci_ = is_inside_ci()
     is_mac_ = is_mac()
+    is_external_linux_ = is_external_linux()
     # One and only one set-up should be true.
     sum_ = sum(
         [
@@ -235,6 +249,7 @@ def _dassert_setup_consistency() -> None:
             is_dev_ck_,
             is_inside_ci_,
             is_mac_,
+            is_external_linux_,
             is_cmamp_prod_,
             is_ig_prod_,
         ]

--- a/helpers/hserver.py
+++ b/helpers/hserver.py
@@ -161,13 +161,13 @@ def is_mac(*, version: Optional[str] = None) -> bool:
 
 def is_external_linux() -> bool:
     """
-    Detect whether we are running on a non-server Linux machine.
+    Detect whether we are running on a non-server/non-CI Linux machine.
 
     :return: whether an external Linux system is running
     """
     host_os_name = os.uname()[0]
-    if host_os_name == "Linux" and not is_dev_ck():
-        # Running a Linux system but not on a dev server.
+    if host_os_name == "Linux" and not (is_dev_ck() or is_inside_ci()):
+        # Running a Linux system but not on a dev server and not within CI flow.
         return True
     return False
 

--- a/helpers/hserver.py
+++ b/helpers/hserver.py
@@ -227,6 +227,9 @@ def setup_to_str() -> str:
     is_mac_ = is_mac()
     txt.append(f"is_mac={is_mac_}")
     #
+    is_external_linux_ = is_external_linux()
+    txt.append(f"is_external_linux={is_external_linux_}")
+    #
     txt = "\n".join(txt)
     return txt
 

--- a/helpers/lib_tasks_docker.py
+++ b/helpers/lib_tasks_docker.py
@@ -398,7 +398,10 @@ def docker_login(ctx, target_registry="aws_ecr.ck"):  # type: ignore
     hlitauti.report_task()
     # No login required as the `helpers` container is accessible on
     # the public DockerHub registry.
-    if hrecouti.get_repo_config().get_name() == "//helpers":
+    if (
+        not hserver.is_dev_ck()
+        and hrecouti.get_repo_config().get_name() == "//helpers"
+    ):
         _LOG.warning("Skipping logging in for Helpers")
         return
     # We run everything using `hsystem.system(...)` but `ctx` is needed

--- a/helpers/lib_tasks_docker.py
+++ b/helpers/lib_tasks_docker.py
@@ -396,10 +396,10 @@ def docker_login(ctx, target_registry="aws_ecr.ck"):  # type: ignore
     """
     _ = ctx
     hlitauti.report_task()
-    # No login required as kaizenflow container is accessible on the public
-    # DockerHub registry.
-    if hrecouti.get_repo_config().get_name() == "//kaizen":
-        _LOG.warning("Skipping logging in for Kaizenflow")
+    # No login required as the `helpers` container is accessible on
+    # the public DockerHub registry.
+    if hrecouti.get_repo_config().get_name() == "//helpers":
+        _LOG.warning("Skipping logging in for Helpers")
         return
     # We run everything using `hsystem.system(...)` but `ctx` is needed
     # to make the function work as an invoke target.


### PR DESCRIPTION
Related to #377 
- Previously we force-installed version 5.3.1 of `pyyaml` only on Mac
- Now we would do that also on Linux if it's not on our dev server
- There is also `is_dev4()` function in `hserver`. Do we want to add it to the condition as well? I don't know if it has a special status of some sort (given that it has its own function unlike the other three).