### PR TITLE
Remove Docker registry argument from intern onboarding guide

### DIFF
--- a/docs/onboarding/intern.set_up_development_on_laptop.how_to_guide.md
+++ b/docs/onboarding/intern.set_up_development_on_laptop.how_to_guide.md
@@ -261,7 +261,7 @@
 - Pull the latest `helpers` image containing Linter; this is done once
 
   ```bash
-  > i docker_pull_helpers --docker-registry dockerhub.causify
+  > i docker_pull_helpers
   ```
 
 - Get the latest version of `master`


### PR DESCRIPTION
### Summary
Removed the outdated reference to the `docker-registry` argument in the intern onboarding guide. (`docs/onboarding/intern.set_up_development_on_laptop.how_to_guide.md`)

### Reason
 Docker registry integration is deprecated (see issue #410).
