### PR TITLE
Fix Docker "Permission Denied" Error

### DIFF
--- a/docs/onboarding/intern.set_up_development_on_laptop.how_to_guide.md
+++ b/docs/onboarding/intern.set_up_development_on_laptop.how_to_guide.md
@@ -262,7 +262,10 @@
   > sudo usermod -aG docker $USER
   # log out and log back in after executing this command.
   ```
-  
+- Verify Access:
+  ```bash
+  docker run hello-world  # Should work without "permission denied"
+  ```
 
 - Pull the latest `helpers` image containing Linter; this is done once
 

--- a/docs/onboarding/intern.set_up_development_on_laptop.how_to_guide.md
+++ b/docs/onboarding/intern.set_up_development_on_laptop.how_to_guide.md
@@ -257,6 +257,12 @@
   ```bash
   > i docker_pull
   ```
+- If you get an error (Linux) ```permission denied while trying to connect to the Docker daemon socket```, you have to grant permission to your user account to interact with Docker. Adding user to the ```docker group``` grants permission to use Docker without ```sudo```:
+  ```bash
+  > sudo usermod -aG docker $USER
+  # log out and log back in after executing this command.
+  ```
+  
 
 - Pull the latest `helpers` image containing Linter; this is done once
 


### PR DESCRIPTION
Issue: permission denied while trying to connect to the Docker daemon socket

Quick Fix:

    1. Add your user to the docker group:

    2. Log out and log back in (or reboot)

    3. Verify access

Why?

Docker requires root-equivalent privileges. Adding your user to the docker group grants persistent access to the Docker socket (/var/run/docker.sock).