### PR TITLE
HelpersTask398_Registry_login_for_the_tutorials_repo

### DIFF
--- a/helpers/lib_tasks_docker.py
+++ b/helpers/lib_tasks_docker.py
@@ -396,11 +396,11 @@ def docker_login(ctx, target_registry="aws_ecr.ck"):  # type: ignore
     """
     _ = ctx
     hlitauti.report_task()
-    # No login required as the `helpers` container is accessible on
-    # the public DockerHub registry.
+    # No login required as the `helpers` and `tutorials` images are accessible
+    # on the public DockerHub registry.
     if (
         not hserver.is_dev_ck()
-        and hrecouti.get_repo_config().get_name() == "//helpers"
+        and hrecouti.get_repo_config().get_name() in ["//helpers", "//tutorials"]
     ):
         _LOG.warning("Skipping logging in for Helpers")
         return

--- a/helpers/lib_tasks_docker.py
+++ b/helpers/lib_tasks_docker.py
@@ -398,10 +398,10 @@ def docker_login(ctx, target_registry="aws_ecr.ck"):  # type: ignore
     hlitauti.report_task()
     # No login required as the `helpers` and `tutorials` images are accessible
     # on the public DockerHub registry.
-    if (
-        not hserver.is_dev_ck()
-        and hrecouti.get_repo_config().get_name() in ["//helpers", "//tutorials"]
-    ):
+    if not hserver.is_dev_ck() and hrecouti.get_repo_config().get_name() in [
+        "//helpers",
+        "//tutorials",
+    ]:
         _LOG.warning("Skipping Docker login process for Helpers or Tutorials")
         return
     # We run everything using `hsystem.system(...)` but `ctx` is needed

--- a/helpers/lib_tasks_docker.py
+++ b/helpers/lib_tasks_docker.py
@@ -402,7 +402,7 @@ def docker_login(ctx, target_registry="aws_ecr.ck"):  # type: ignore
         not hserver.is_dev_ck()
         and hrecouti.get_repo_config().get_name() in ["//helpers", "//tutorials"]
     ):
-        _LOG.warning("Skipping logging in for Helpers")
+        _LOG.warning("Skipping Docker login process for Helpers or Tutorials")
         return
     # We run everything using `hsystem.system(...)` but `ctx` is needed
     # to make the function work as an invoke target.


### PR DESCRIPTION
#398

- no login required in the `docker_login()` if the current repo is `tutorials`