### PR TITLE
Fix #417: Correct typo in all.team_collaboration.how_to_guide.md (retry)

### DIFF
--- a/docs/work_organization/all.team_collaboration.how_to_guide.md
+++ b/docs/work_organization/all.team_collaboration.how_to_guide.md
@@ -235,7 +235,7 @@ The idea is to send a morning TODO email to broadcast:
 - The goal is:
   - Think about what you are going to work on for the day, so you have a clear
     plan
-  - Let Team Leaders know that you're going work today and what is your workload
+  - Let Team Leaders know that you're going to work today and what is your workload
   - Make sure people blocked on your tasks know that / whether you are working
     on those tasks
   - Broadcast if you are blocked or if you don't have tasks

--- a/docs/work_organization/all.team_collaboration.how_to_guide.md
+++ b/docs/work_organization/all.team_collaboration.how_to_guide.md
@@ -235,7 +235,8 @@ The idea is to send a morning TODO email to broadcast:
 - The goal is:
   - Think about what you are going to work on for the day, so you have a clear
     plan
-  - Let Team Leaders know that you're going to work today and what is your workload
+  - Let Team Leaders know that you're going to work today and what is your
+    workload
   - Make sure people blocked on your tasks know that / whether you are working
     on those tasks
   - Broadcast if you are blocked or if you don't have tasks


### PR DESCRIPTION
This PR addresses Issue https://github.com/causify-ai/helpers/issues/417 by adding the missing “to” in the sentence:
> Let Team Leaders know that you're going to work today and what is your workload

