### PR TITLE
Update all.coding_style.how_to_guide.md

### DIFF
--- a/docs/coding/all.coding_style.how_to_guide.md
+++ b/docs/coding/all.coding_style.how_to_guide.md
@@ -2340,7 +2340,7 @@
   positives.
 - Then we always want to permit disabling the automatic checks / fixes e.g., by
   using directives in comments or special syntax (e.g., anything in a `...` or
-  `...` block should be leaved untouched)
+  `...` block should be left untouched)
 - It can be tricky determining when an exception is really needed and when
   overriding the tool becomes a slippery slope for ignoring the rules.
 - Patience and flexibility is advised here.


### PR DESCRIPTION
Related to #427

This PR corrects a typo in `all.coding_style.how_to_guide.md`:

- Changed **"leaved"** → **"left"** in the phrase _"block should be leaved untouched"_