### PR TITLE
HelpersTask435_Fix_typo_in_all.writing_docs.how_to_guide.md

### DIFF
--- a/docs/documentation_meta/all.writing_docs.how_to_guide.md
+++ b/docs/documentation_meta/all.writing_docs.how_to_guide.md
@@ -243,7 +243,7 @@
 
 **Bad**
 
-- There configurations can be changed by ...
+- These configurations can be changed by ...
 
 ### Use simple short sentences
 


### PR DESCRIPTION
Related to #435 

This PR updates a typo in `docs/documentation_meta/all.writing_docs.how_to_guide.md` under subsection `Use active voice`

Original text:

> There configurations can be changed by ...

Updated text:

> These configurations can be changed by ...