### PR TITLE
Update intern.set_up_development_on_laptop.how_to_guide.md

### DIFF
--- a/docs/onboarding/intern.set_up_development_on_laptop.how_to_guide.md
+++ b/docs/onboarding/intern.set_up_development_on_laptop.how_to_guide.md
@@ -257,6 +257,15 @@
   ```bash
   > i docker_pull
   ```
+- If you get an error (Linux) ```permission denied while trying to connect to the Docker daemon socket```, you have to grant permission to your user account to interact with Docker. Adding user to the ```docker group``` grants permission to use Docker without ```sudo```:
+  ```bash
+  > sudo usermod -aG docker $USER
+  # log out and log back in after executing this command.
+  ```
+- Verify Access:
+  ```bash
+  docker run hello-world  # Should work without "permission denied"
+  ```
 
 - Pull the latest `helpers` image containing Linter; this is done once
 


### PR DESCRIPTION
**Error:**
_`permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock`_

**Root Cause:**
_Docker requires root-equivalent privileges. By default, only the root user or members of the docker group have access to the Docker socket (/var/run/docker.sock). New users are not automatically added to the docker group._

**Affected Workflow:**
_Running Docker commands (e.g., docker run, docker compose) as a non-root user._


**Quick Fix:**

1. Add your user to the docker group:

2. Log out and log back in (or reboot)

3. Verify access

**Why?**

Docker requires root-equivalent privileges. Adding your user to the docker group grants persistent access to the Docker socket (/var/run/docker.sock).