### PR TITLE
HelpersTask301_dot_at_beginning_of_dir_is_removed

### DIFF
--- a/linters/amp_fix_md_links.py
+++ b/linters/amp_fix_md_links.py
@@ -38,7 +38,7 @@ def _make_path_absolute(path: str) -> str:
     :param path: the original path
     :return: the absolute path
     """
-    # Converts path beginning with './', '../', '../../'.
+    # Transform paths that begin with './', '../', '../../'.
     abs_path = re.sub(r"^(\./|\.\./|\.\./\.\./)*", "", path)
     abs_path = "/" + abs_path.lstrip("/")
     return abs_path

--- a/linters/amp_fix_md_links.py
+++ b/linters/amp_fix_md_links.py
@@ -38,7 +38,7 @@ def _make_path_absolute(path: str) -> str:
     :param path: the original path
     :return: the absolute path
     """
-    # Transform paths that begin with './', '../', '../../'.
+    # Converts path beginning with './', '../', '../../'.
     abs_path = re.sub(r"^(\./|\.\./|\.\./\.\./)*", "", path)
     abs_path = "/" + abs_path.lstrip("/")
     return abs_path

--- a/linters/amp_fix_md_links.py
+++ b/linters/amp_fix_md_links.py
@@ -38,11 +38,9 @@ def _make_path_absolute(path: str) -> str:
     :param path: the original path
     :return: the absolute path
     """
-    if path.startswith("./"):
-        abs_path = path[2:]
-    else:
-        abs_path = path.lstrip("/")
-    abs_path = "/" + abs_path
+    # Converts path beginning with './', '../', '../../'.
+    abs_path = re.sub(r"^(\./|\.\./|\.\./\.\./)*", "", path)
+    abs_path = "/" + abs_path.lstrip("/")
     return abs_path
 
 

--- a/linters/amp_fix_md_links.py
+++ b/linters/amp_fix_md_links.py
@@ -38,8 +38,7 @@ def _make_path_absolute(path: str) -> str:
     :param path: the original path
     :return: the absolute path
     """
-    abs_path = path.lstrip("./")
-    abs_path = "/" + abs_path
+    abs_path = path.lstrip(".")
     return abs_path
 
 

--- a/linters/amp_fix_md_links.py
+++ b/linters/amp_fix_md_links.py
@@ -38,7 +38,11 @@ def _make_path_absolute(path: str) -> str:
     :param path: the original path
     :return: the absolute path
     """
-    abs_path = path.lstrip(".")
+    if path.startswith("./"):
+        abs_path = path[2:]
+    else:
+        abs_path = path.lstrip("/")
+    abs_path = "/" + abs_path
     return abs_path
 
 

--- a/linters/test/outcomes/Test_fix_links.test1/output/test.txt
+++ b/linters/test/outcomes/Test_fix_links.test1/output/test.txt
@@ -1,17 +1,18 @@
 # linter warnings
 
 /app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:38: '/helpersssss/hhhhgit.py' does not exist
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:74: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:41: '/.github/workflows/sprint_iteration.yml' does not exist
 /app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:77: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:80: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:83: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:83: '/iiimport_check/example/output/basicccc.png' does not exist
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:86: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:80: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:83: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:86: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:86: '/iiimport_check/example/output/basicccc.png' does not exist
 /app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:89: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:93: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:96: '../../import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:99: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:99: '/iiimport_check/example/output/basicccc.png' does not exist
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:92: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:96: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:99: '../../import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:102: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:102: '/iiimport_check/example/output/basicccc.png' does not exist
 
 # linted file
 
@@ -54,6 +55,9 @@
 
 - Markdown-style link to a file that does not exist
   - [File not found](/helpersssss/hhhhgit.py)
+
+- Markdown-style link with a directory beginning with a dot
+  - [`sprint_iteration.yml`](/.github/workflows/sprint_iteration.yml)
 
 - File path without the backticks
   - /helpers/test/test_hdbg.py

--- a/linters/test/outcomes/Test_fix_links.test1/output/test.txt
+++ b/linters/test/outcomes/Test_fix_links.test1/output/test.txt
@@ -1,17 +1,18 @@
 # linter warnings
 
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:38: '/helpersssss/hhhhgit.py' does not exist
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:74: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:77: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:80: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:83: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:83: '/iiimport_check/example/output/basicccc.png' does not exist
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:86: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:89: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:93: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:96: '../../import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:99: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:99: '/iiimport_check/example/output/basicccc.png' does not exist
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:38: '/helpersssss/hhhhgit.py' does not exist
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:41: '/.github/workflows/sprint_iteration.yml' does not exist
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:77: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:80: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:83: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:86: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:86: '/iiimport_check/example/output/basicccc.png' does not exist
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:89: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:92: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:96: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:99: '../../import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:102: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:102: '/iiimport_check/example/output/basicccc.png' does not exist
 
 # linted file
 
@@ -54,6 +55,9 @@
 
 - Markdown-style link to a file that does not exist
   - [File not found](/helpersssss/hhhhgit.py)
+
+- Markdown-style link with a directory beginning with a dot
+  - [`sprint_iteration.yml`](/.github/workflows/sprint_iteration.yml)
 
 - File path without the backticks
   - /helpers/test/test_hdbg.py

--- a/linters/test/outcomes/Test_fix_links.test1/output/test.txt
+++ b/linters/test/outcomes/Test_fix_links.test1/output/test.txt
@@ -1,17 +1,18 @@
 # linter warnings
 
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:38: '/helpersssss/hhhhgit.py' does not exist
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:74: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:77: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:80: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:83: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:83: '/iiimport_check/example/output/basicccc.png' does not exist
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:86: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:89: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:93: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:96: '../../import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:99: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:99: '/iiimport_check/example/output/basicccc.png' does not exist
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:38: '/helpersssss/hhhhgit.py' does not exist
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:41: '/.github/workflows/sprint_iteration.yml' does not exist
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:77: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:80: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:83: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:86: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:86: '/iiimport_check/example/output/basicccc.png' does not exist
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:89: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:92: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:96: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:99: '../../import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:102: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:102: '/iiimport_check/example/output/basicccc.png' does not exist
 
 # linted file
 
@@ -54,6 +55,9 @@
 
 - Markdown-style link to a file that does not exist
   - [File not found](/helpersssss/hhhhgit.py)
+
+- Markdown-style link with directory beginning with a dot
+  - [`sprint_iteration.yml`](/.github/workflows/sprint_iteration.yml)
 
 - File path without the backticks
   - /helpers/test/test_hdbg.py

--- a/linters/test/outcomes/Test_fix_links.test1/output/test.txt
+++ b/linters/test/outcomes/Test_fix_links.test1/output/test.txt
@@ -1,7 +1,6 @@
 # linter warnings
 
 /app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:38: '/helpersssss/hhhhgit.py' does not exist
-/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:41: '/.github/workflows/sprint_iteration.yml' does not exist
 /app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:77: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
 /app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:80: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
 /app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:83: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'

--- a/linters/test/outcomes/Test_fix_links.test1/output/test.txt
+++ b/linters/test/outcomes/Test_fix_links.test1/output/test.txt
@@ -1,18 +1,17 @@
 # linter warnings
 
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:38: '/helpersssss/hhhhgit.py' does not exist
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:41: '/.github/workflows/sprint_iteration.yml' does not exist
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:77: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:80: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:83: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:86: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:86: '/iiimport_check/example/output/basicccc.png' does not exist
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:89: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:92: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:96: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:99: '../../import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:102: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:102: '/iiimport_check/example/output/basicccc.png' does not exist
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:38: '/helpersssss/hhhhgit.py' does not exist
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:74: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:77: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:80: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:83: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:83: '/iiimport_check/example/output/basicccc.png' does not exist
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:86: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:89: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:93: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:96: '../../import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:99: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:99: '/iiimport_check/example/output/basicccc.png' does not exist
 
 # linted file
 
@@ -55,9 +54,6 @@
 
 - Markdown-style link to a file that does not exist
   - [File not found](/helpersssss/hhhhgit.py)
-
-- Markdown-style link with a directory beginning with a dot
-  - [`sprint_iteration.yml`](/.github/workflows/sprint_iteration.yml)
 
 - File path without the backticks
   - /helpers/test/test_hdbg.py

--- a/linters/test/outcomes/Test_fix_links.test1/output/test.txt
+++ b/linters/test/outcomes/Test_fix_links.test1/output/test.txt
@@ -1,18 +1,17 @@
 # linter warnings
 
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:38: '/helpersssss/hhhhgit.py' does not exist
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:41: '/.github/workflows/sprint_iteration.yml' does not exist
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:77: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:80: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:83: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:86: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:86: '/iiimport_check/example/output/basicccc.png' does not exist
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:89: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:92: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:96: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:99: '../../import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:102: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:102: '/iiimport_check/example/output/basicccc.png' does not exist
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:38: '/helpersssss/hhhhgit.py' does not exist
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:74: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:77: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:80: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:83: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:83: '/iiimport_check/example/output/basicccc.png' does not exist
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:86: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:89: 'import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:93: '/import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:96: '../../import_check/example/output/basic.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:99: '/iiimport_check/example/output/basicccc.png' does not follow the format 'figs/test.md/XYZ'
+/app/linters/test/outcomes/Test_fix_links.test1/tmp.scratch/test.md:99: '/iiimport_check/example/output/basicccc.png' does not exist
 
 # linted file
 
@@ -55,9 +54,6 @@
 
 - Markdown-style link to a file that does not exist
   - [File not found](/helpersssss/hhhhgit.py)
-
-- Markdown-style link with directory beginning with a dot
-  - [`sprint_iteration.yml`](/.github/workflows/sprint_iteration.yml)
 
 - File path without the backticks
   - /helpers/test/test_hdbg.py

--- a/linters/test/outcomes/Test_fix_links.test1/output/test.txt
+++ b/linters/test/outcomes/Test_fix_links.test1/output/test.txt
@@ -56,7 +56,7 @@
   - [File not found](/helpersssss/hhhhgit.py)
 
 - Markdown-style link with a directory beginning with a dot
-  - [`sprint_iteration.yml`](/.github/workflows/sprint_iteration.yml)
+  - [`fast_tests.yml`](/.github/workflows/fast_tests.yml)
 
 - File path without the backticks
   - /helpers/test/test_hdbg.py

--- a/linters/test/outcomes/Test_fix_links.test3/output/test.txt
+++ b/linters/test/outcomes/Test_fix_links.test3/output/test.txt
@@ -1,10 +1,10 @@
 # linter warnings
 
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:1: '/docs/markdown_example.md' does not exist
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:3: '/docs/html_example.md' does not exist
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:5: '/missing_markdown.md' does not exist
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:7: '/missing_html.md' does not exist
-/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:13: '/nested.md)' does not exist
+/app/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:1: '/docs/markdown_example.md' does not exist
+/app/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:3: '/docs/html_example.md' does not exist
+/app/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:5: '/missing_markdown.md' does not exist
+/app/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:7: '/missing_html.md' does not exist
+/app/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:13: '/nested.md)' does not exist
 
 # linted file
 

--- a/linters/test/outcomes/Test_fix_links.test3/output/test.txt
+++ b/linters/test/outcomes/Test_fix_links.test3/output/test.txt
@@ -1,10 +1,10 @@
 # linter warnings
 
-/app/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:1: '/docs/markdown_example.md' does not exist
-/app/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:3: '/docs/html_example.md' does not exist
-/app/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:5: '/missing_markdown.md' does not exist
-/app/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:7: '/missing_html.md' does not exist
-/app/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:13: '/nested.md)' does not exist
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:1: '/docs/markdown_example.md' does not exist
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:3: '/docs/html_example.md' does not exist
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:5: '/missing_markdown.md' does not exist
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:7: '/missing_html.md' does not exist
+/Users/allenmathews/src/helpers1/linters/test/outcomes/Test_fix_links.test3/tmp.scratch/test_combined.md:13: '/nested.md)' does not exist
 
 # linted file
 

--- a/linters/test/test_amp_fix_md_links.py
+++ b/linters/test/test_amp_fix_md_links.py
@@ -101,50 +101,6 @@ class Test_fix_links(hunitest.TestCase):
         )
         self.check_string(output)
 
-    def test4(self) -> None:
-        """
-        Test file path to retain directory name beginning with a dot.
-        """
-        file_path = "/.github/workflows/sprint_iteration.yml"
-        expected_path = "/.github/workflows/sprint_iteration.yml"
-        # Run.
-        actual_path = lafimdli._make_path_absolute(file_path)
-        # Check.
-        self.assertEqual(actual_path, expected_path)
-
-    def test5(self) -> None:
-        """
-        Test to make file path absolute.
-        """
-        file_path = "./.github/workflows/sprint_iteration.yml"
-        expected_path = "/.github/workflows/sprint_iteration.yml"
-        # Run.
-        actual_path = lafimdli._make_path_absolute(file_path)
-        # Check.
-        self.assertEqual(actual_path, expected_path)
-
-    def test6(self) -> None:
-        """
-        Test to make file path absolute.
-        """
-        file_path = "../.github/workflows/sprint_iteration.yml"
-        expected_path = "/.github/workflows/sprint_iteration.yml"
-        # Run.
-        actual_path = lafimdli._make_path_absolute(file_path)
-        # Check.
-        self.assertEqual(actual_path, expected_path)
-
-    def test7(self) -> None:
-        """
-        Test to make file path absolute.
-        """
-        file_path = "../../.github/workflows/sprint_iteration.yml"
-        expected_path = "/.github/workflows/sprint_iteration.yml"
-        # Run.
-        actual_path = lafimdli._make_path_absolute(file_path)
-        # Check.
-        self.assertEqual(actual_path, expected_path)
-
     def _get_txt_with_incorrect_links(self) -> str:
         txt_incorrect = r"""
 - Markdown-style link with a text label
@@ -265,3 +221,55 @@ height="1.2303444881889765in"}
         # Create the file.
         hio.to_file(file_path, txt)
         return file_path
+
+
+# #############################################################################
+# Test_make_path_absolute
+# #############################################################################
+
+
+class Test_make_path_absolute(hunitest.TestCase):
+
+    def test_make_path_absolute1(self) -> None:
+        """
+        Test file path to retain directory name beginning with a dot.
+        """
+        file_path = "/.github/workflows/sprint_iteration.yml"
+        expected = "/.github/workflows/sprint_iteration.yml"
+        # Run.
+        actual = lafimdli._make_path_absolute(file_path)
+        # Check.
+        self.assertEqual(actual, expected)
+
+    def test_make_path_absolute2(self) -> None:
+        """
+        Test to make file path absolute.
+        """
+        file_path = "./.github/workflows/sprint_iteration.yml"
+        expected = "/.github/workflows/sprint_iteration.yml"
+        # Run.
+        actual = lafimdli._make_path_absolute(file_path)
+        # Check.
+        self.assertEqual(actual, expected)
+
+    def test_make_path_absolute3(self) -> None:
+        """
+        Test to make file path absolute.
+        """
+        file_path = "../.github/workflows/sprint_iteration.yml"
+        expected = "/.github/workflows/sprint_iteration.yml"
+        # Run.
+        actual = lafimdli._make_path_absolute(file_path)
+        # Check.
+        self.assertEqual(actual, expected)
+
+    def test_make_path_absolute4(self) -> None:
+        """
+        Test to make file path absolute.
+        """
+        file_path = "../../.github/workflows/sprint_iteration.yml"
+        expected = "/.github/workflows/sprint_iteration.yml"
+        # Run.
+        actual = lafimdli._make_path_absolute(file_path)
+        # Check.
+        self.assertEqual(actual, expected)

--- a/linters/test/test_amp_fix_md_links.py
+++ b/linters/test/test_amp_fix_md_links.py
@@ -112,6 +112,39 @@ class Test_fix_links(hunitest.TestCase):
         # Check.
         self.assertEqual(actual_path, expected_path)
 
+    def test5(self) -> None:
+        """
+        Test to make file path absolute.
+        """
+        file_path = "./.github/workflows/sprint_iteration.yml"
+        expected_path = "/.github/workflows/sprint_iteration.yml"
+        # Run.
+        actual_path = lafimdli._make_path_absolute(file_path)
+        # Check.
+        self.assertEqual(actual_path, expected_path)
+
+    def test6(self) -> None:
+        """
+        Test to make file path absolute.
+        """
+        file_path = "../.github/workflows/sprint_iteration.yml"
+        expected_path = "/.github/workflows/sprint_iteration.yml"
+        # Run.
+        actual_path = lafimdli._make_path_absolute(file_path)
+        # Check.
+        self.assertEqual(actual_path, expected_path)
+
+    def test7(self) -> None:
+        """
+        Test to make file path absolute.
+        """
+        file_path = "../../.github/workflows/sprint_iteration.yml"
+        expected_path = "/.github/workflows/sprint_iteration.yml"
+        # Run.
+        actual_path = lafimdli._make_path_absolute(file_path)
+        # Check.
+        self.assertEqual(actual_path, expected_path)
+
     def _get_txt_with_incorrect_links(self) -> str:
         txt_incorrect = r"""
 - Markdown-style link with a text label

--- a/linters/test/test_amp_fix_md_links.py
+++ b/linters/test/test_amp_fix_md_links.py
@@ -143,7 +143,7 @@ class Test_fix_links(hunitest.TestCase):
   - [File not found](/helpersssss/hhhhgit.py)
 
 - Markdown-style link with a directory beginning with a dot
-  - [`sprint_iteration.yml`](/.github/workflows/sprint_iteration.yml)
+  - [`fast_tests.yml`](/.github/workflows/fast_tests.yml)
 
 - File path without the backticks
   - /helpers/test/test_hdbg.py

--- a/linters/test/test_amp_fix_md_links.py
+++ b/linters/test/test_amp_fix_md_links.py
@@ -142,6 +142,9 @@ class Test_fix_links(hunitest.TestCase):
 - Markdown-style link to a file that does not exist
   - [File not found](/helpersssss/hhhhgit.py)
 
+- Markdown-style link with a directory beginning with a dot
+  - [`sprint_iteration.yml`](/.github/workflows/sprint_iteration.yml)
+
 - File path without the backticks
   - /helpers/test/test_hdbg.py
 

--- a/linters/test/test_amp_fix_md_links.py
+++ b/linters/test/test_amp_fix_md_links.py
@@ -101,6 +101,50 @@ class Test_fix_links(hunitest.TestCase):
         )
         self.check_string(output)
 
+    def test4(self) -> None:
+        """
+        Test file path to retain directory name beginning with a dot.
+        """
+        file_path = "/.github/workflows/sprint_iteration.yml"
+        expected_path = "/.github/workflows/sprint_iteration.yml"
+        # Run.
+        actual_path = lafimdli._make_path_absolute(file_path)
+        # Check.
+        self.assertEqual(actual_path, expected_path)
+
+    def test5(self) -> None:
+        """
+        Test to make file path absolute.
+        """
+        file_path = "./.github/workflows/sprint_iteration.yml"
+        expected_path = "/.github/workflows/sprint_iteration.yml"
+        # Run.
+        actual_path = lafimdli._make_path_absolute(file_path)
+        # Check.
+        self.assertEqual(actual_path, expected_path)
+
+    def test6(self) -> None:
+        """
+        Test to make file path absolute.
+        """
+        file_path = "../.github/workflows/sprint_iteration.yml"
+        expected_path = "/.github/workflows/sprint_iteration.yml"
+        # Run.
+        actual_path = lafimdli._make_path_absolute(file_path)
+        # Check.
+        self.assertEqual(actual_path, expected_path)
+
+    def test7(self) -> None:
+        """
+        Test to make file path absolute.
+        """
+        file_path = "../../.github/workflows/sprint_iteration.yml"
+        expected_path = "/.github/workflows/sprint_iteration.yml"
+        # Run.
+        actual_path = lafimdli._make_path_absolute(file_path)
+        # Check.
+        self.assertEqual(actual_path, expected_path)
+
     def _get_txt_with_incorrect_links(self) -> str:
         txt_incorrect = r"""
 - Markdown-style link with a text label
@@ -141,9 +185,6 @@ class Test_fix_links(hunitest.TestCase):
 
 - Markdown-style link to a file that does not exist
   - [File not found](/helpersssss/hhhhgit.py)
-
-- Markdown-style link with directory beginning with a dot
-  - [`sprint_iteration.yml`](/.github/workflows/sprint_iteration.yml)
 
 - File path without the backticks
   - /helpers/test/test_hdbg.py
@@ -224,55 +265,3 @@ height="1.2303444881889765in"}
         # Create the file.
         hio.to_file(file_path, txt)
         return file_path
-
-
-# #############################################################################
-# Test_make_path_absolute
-# #############################################################################
-
-
-class Test_make_path_absolute(hunitest.TestCase):
-
-    def test_make_path_absolute1(self) -> None:
-        """
-        Test file path to retain directory name beginning with a dot.
-        """
-        file_path = "/.github/workflows/sprint_iteration.yml"
-        expected = "/.github/workflows/sprint_iteration.yml"
-        # Run.
-        actual = lafimdli._make_path_absolute(file_path)
-        # Check.
-        self.assertEqual(actual, expected)
-
-    def test_make_path_absolute2(self) -> None:
-        """
-        Test to make file path absolute.
-        """
-        file_path = "./.github/workflows/sprint_iteration.yml"
-        expected = "/.github/workflows/sprint_iteration.yml"
-        # Run.
-        actual = lafimdli._make_path_absolute(file_path)
-        # Check.
-        self.assertEqual(actual, expected)
-
-    def test_make_path_absolute3(self) -> None:
-        """
-        Test to make file path absolute.
-        """
-        file_path = "../.github/workflows/sprint_iteration.yml"
-        expected = "/.github/workflows/sprint_iteration.yml"
-        # Run.
-        actual = lafimdli._make_path_absolute(file_path)
-        # Check.
-        self.assertEqual(actual, expected)
-
-    def test_make_path_absolute4(self) -> None:
-        """
-        Test to make file path absolute.
-        """
-        file_path = "../../.github/workflows/sprint_iteration.yml"
-        expected = "/.github/workflows/sprint_iteration.yml"
-        # Run.
-        actual = lafimdli._make_path_absolute(file_path)
-        # Check.
-        self.assertEqual(actual, expected)

--- a/linters/test/test_amp_fix_md_links.py
+++ b/linters/test/test_amp_fix_md_links.py
@@ -101,50 +101,6 @@ class Test_fix_links(hunitest.TestCase):
         )
         self.check_string(output)
 
-    def test4(self) -> None:
-        """
-        Test file path to retain directory name beginning with a dot.
-        """
-        file_path = "/.github/workflows/sprint_iteration.yml"
-        expected_path = "/.github/workflows/sprint_iteration.yml"
-        # Run.
-        actual_path = lafimdli._make_path_absolute(file_path)
-        # Check.
-        self.assertEqual(actual_path, expected_path)
-
-    def test5(self) -> None:
-        """
-        Test to make file path absolute.
-        """
-        file_path = "./.github/workflows/sprint_iteration.yml"
-        expected_path = "/.github/workflows/sprint_iteration.yml"
-        # Run.
-        actual_path = lafimdli._make_path_absolute(file_path)
-        # Check.
-        self.assertEqual(actual_path, expected_path)
-
-    def test6(self) -> None:
-        """
-        Test to make file path absolute.
-        """
-        file_path = "../.github/workflows/sprint_iteration.yml"
-        expected_path = "/.github/workflows/sprint_iteration.yml"
-        # Run.
-        actual_path = lafimdli._make_path_absolute(file_path)
-        # Check.
-        self.assertEqual(actual_path, expected_path)
-
-    def test7(self) -> None:
-        """
-        Test to make file path absolute.
-        """
-        file_path = "../../.github/workflows/sprint_iteration.yml"
-        expected_path = "/.github/workflows/sprint_iteration.yml"
-        # Run.
-        actual_path = lafimdli._make_path_absolute(file_path)
-        # Check.
-        self.assertEqual(actual_path, expected_path)
-
     def _get_txt_with_incorrect_links(self) -> str:
         txt_incorrect = r"""
 - Markdown-style link with a text label
@@ -185,6 +141,9 @@ class Test_fix_links(hunitest.TestCase):
 
 - Markdown-style link to a file that does not exist
   - [File not found](/helpersssss/hhhhgit.py)
+
+- Markdown-style link with directory beginning with a dot
+  - [`sprint_iteration.yml`](/.github/workflows/sprint_iteration.yml)
 
 - File path without the backticks
   - /helpers/test/test_hdbg.py
@@ -265,3 +224,55 @@ height="1.2303444881889765in"}
         # Create the file.
         hio.to_file(file_path, txt)
         return file_path
+
+
+# #############################################################################
+# Test_make_path_absolute
+# #############################################################################
+
+
+class Test_make_path_absolute(hunitest.TestCase):
+
+    def test_make_path_absolute1(self) -> None:
+        """
+        Test file path to retain directory name beginning with a dot.
+        """
+        file_path = "/.github/workflows/sprint_iteration.yml"
+        expected = "/.github/workflows/sprint_iteration.yml"
+        # Run.
+        actual = lafimdli._make_path_absolute(file_path)
+        # Check.
+        self.assertEqual(actual, expected)
+
+    def test_make_path_absolute2(self) -> None:
+        """
+        Test to make file path absolute.
+        """
+        file_path = "./.github/workflows/sprint_iteration.yml"
+        expected = "/.github/workflows/sprint_iteration.yml"
+        # Run.
+        actual = lafimdli._make_path_absolute(file_path)
+        # Check.
+        self.assertEqual(actual, expected)
+
+    def test_make_path_absolute3(self) -> None:
+        """
+        Test to make file path absolute.
+        """
+        file_path = "../.github/workflows/sprint_iteration.yml"
+        expected = "/.github/workflows/sprint_iteration.yml"
+        # Run.
+        actual = lafimdli._make_path_absolute(file_path)
+        # Check.
+        self.assertEqual(actual, expected)
+
+    def test_make_path_absolute4(self) -> None:
+        """
+        Test to make file path absolute.
+        """
+        file_path = "../../.github/workflows/sprint_iteration.yml"
+        expected = "/.github/workflows/sprint_iteration.yml"
+        # Run.
+        actual = lafimdli._make_path_absolute(file_path)
+        # Check.
+        self.assertEqual(actual, expected)

--- a/linters/test/test_amp_fix_md_links.py
+++ b/linters/test/test_amp_fix_md_links.py
@@ -101,6 +101,17 @@ class Test_fix_links(hunitest.TestCase):
         )
         self.check_string(output)
 
+    def test4(self) -> None:
+        """
+        Test file path to retain directory name beginning with a dot.
+        """
+        file_path = "/.github/workflows/sprint_iteration.yml"
+        expected_path = "/.github/workflows/sprint_iteration.yml"
+        # Run.
+        actual_path = lafimdli._make_path_absolute(file_path)
+        # Check.
+        self.assertEqual(actual_path, expected_path)
+
     def _get_txt_with_incorrect_links(self) -> str:
         txt_incorrect = r"""
 - Markdown-style link with a text label

--- a/linters/test/test_amp_fix_md_links.py
+++ b/linters/test/test_amp_fix_md_links.py
@@ -143,7 +143,7 @@ class Test_fix_links(hunitest.TestCase):
   - [File not found](/helpersssss/hhhhgit.py)
 
 - Markdown-style link with a directory beginning with a dot
-  - [`sprint_iteration.yml`](/.github/workflows/sprint_iteration.yml)
+  - [`sprint_iteration.yml`](https://github.com/causify-ai/cmamp/blob/master/.github/workflows/sprint_iteration.yml)
 
 - File path without the backticks
   - /helpers/test/test_hdbg.py

--- a/linters/test/test_amp_fix_md_links.py
+++ b/linters/test/test_amp_fix_md_links.py
@@ -143,7 +143,7 @@ class Test_fix_links(hunitest.TestCase):
   - [File not found](/helpersssss/hhhhgit.py)
 
 - Markdown-style link with a directory beginning with a dot
-  - [`sprint_iteration.yml`](https://github.com/causify-ai/cmamp/blob/master/.github/workflows/sprint_iteration.yml)
+  - [`sprint_iteration.yml`](/.github/workflows/sprint_iteration.yml)
 
 - File path without the backticks
   - /helpers/test/test_hdbg.py


### PR DESCRIPTION
Related to #301 

Updated `linters/amp_fix_md_links.py` to fix the directory naming issue in #301 .

Added the same use case to the unit tests in `linters/test/test_amp_fix_md_links.py` to confirm the fix