### PR TITLE
HelpersTask470_Error_when_building_the_thin_env

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,5 @@
     "workbench.colorCustomizations": {
         "titleBar.activeBackground": "#230000",
         "titleBar.activeForeground": "#ffffff"
-    },
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "workbench.colorCustomizations": {
-        "titleBar.activeBackground": "#230000",
-        "titleBar.activeForeground": "#ffffff"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "workbench.colorCustomizations": {
+        "titleBar.activeBackground": "#230000",
+        "titleBar.activeForeground": "#ffffff"
+    },
+}

--- a/dev_scripts_helpers/thin_client/build.py
+++ b/dev_scripts_helpers/thin_client/build.py
@@ -84,8 +84,8 @@ def _main(parser: argparse.ArgumentParser) -> None:
     _system(f"{activate_cmd} && pip3 install -r {tmp_requirements_path}")
     # Show the package list.
     _system("pip3 list")
-    # Darwin specific updates.
     if hserver.is_mac():
+        # Darwin specific updates.
         _system("brew update")
         _, brew_ver = hsystem.system_to_string("brew --version")
         _LOG.info("# brew version=%s", brew_ver)
@@ -97,8 +97,9 @@ def _main(parser: argparse.ArgumentParser) -> None:
         # run_command("brew install dive")
         # dive_ver = run_command("dive --version")
         # _LOG.info("dive version=%s", dive_ver)
-    # Linux specific updates.
-    if hserver.is_external_linux():
+    elif hserver.is_external_linux():
+        # Linux specific updates.
+
         # Install GitHub CLI on linux ubuntu system using apt.
         # Installation instructions based on the official GitHub CLI documentation:
         # https://github.com/cli/cli/blob/trunk/docs/install_linux.md

--- a/dev_scripts_helpers/thin_client/build.py
+++ b/dev_scripts_helpers/thin_client/build.py
@@ -99,7 +99,6 @@ def _main(parser: argparse.ArgumentParser) -> None:
         # _LOG.info("dive version=%s", dive_ver)
     elif hserver.is_external_linux():
         # Linux specific updates.
-
         # Install GitHub CLI on linux ubuntu system using apt.
         # Installation instructions based on the official GitHub CLI documentation:
         # https://github.com/cli/cli/blob/trunk/docs/install_linux.md

--- a/dev_scripts_helpers/thin_client/build.py
+++ b/dev_scripts_helpers/thin_client/build.py
@@ -85,7 +85,7 @@ def _main(parser: argparse.ArgumentParser) -> None:
     # Show the package list.
     _system("pip3 list")
     # Darwin specific updates.
-    if platform.system() == "Darwin":
+    if hserver.is_mac():
         _system("brew update")
         _, brew_ver = hsystem.system_to_string("brew --version")
         _LOG.info("# brew version=%s", brew_ver)
@@ -98,7 +98,7 @@ def _main(parser: argparse.ArgumentParser) -> None:
         # dive_ver = run_command("dive --version")
         # _LOG.info("dive version=%s", dive_ver)
     # Linux specific updates.
-    if platform.system() == "Linux":
+    if hserver.is_external_linux():
         # Install GitHub CLI on linux ubuntu system using apt.
         # Installation instructions based on the official GitHub CLI documentation:
         # https://github.com/cli/cli/blob/trunk/docs/install_linux.md


### PR DESCRIPTION
As per the discussion in #470

Updated the platform check logic from:

```python
if platform.system() == "Linux"
if platform.system() == "Darwin"
```

to:

```python
if hserver.is_external_linux()
if hserver.is_mac()
```

This change ensures that the Github CLI installation process, which requires `sudo` permission, happens on local systems, avoiding dev servers.