### PR TITLE
HelpersTask474_fix_typo_in_collaboration_document

### DIFF
--- a/docs/work_organization/all.team_collaboration.how_to_guide.md
+++ b/docs/work_organization/all.team_collaboration.how_to_guide.md
@@ -30,7 +30,7 @@
 
 # General Rules of Collaboration
 
-- We are not going to discuss and debate the rationale of the following
+- We are not going to discuss and debate the rationale behind the following
   suggestions, but we assume that all is self-evident truth
 
 ## Ask somebody if you have any doubts


### PR DESCRIPTION
Changed the small grammatical error in `docs/work_organization/all.team_collaboration.how_to_guide.md` in the section `# General Rules of Collaboration` at lines 33 - 34 to text:

```
- We are not going to discuss and debate the rationale behind the following 
  suggestions, but we assume that all is self-evident truth
```