### PR TITLE
HelpersTask553_Break_in_slow_tests___dockerized_executables

### DIFF
--- a/helpers/hdocker.py
+++ b/helpers/hdocker.py
@@ -616,7 +616,7 @@ def run_dockerized_prettier(
     )
     # Convert files to Docker paths.
     is_caller_host = not hserver.is_inside_docker()
-    use_sibling_container_for_callee = True
+    use_sibling_container_for_callee = hserver.use_docker_sibling_containers()
     caller_mount_path, callee_mount_path, mount = get_docker_mount_info(
         is_caller_host, use_sibling_container_for_callee
     )
@@ -1045,7 +1045,7 @@ def run_dockerized_markdown_toc(
     )
     # Convert files to Docker paths.
     is_caller_host = not hserver.is_inside_docker()
-    use_sibling_container_for_callee = True
+    use_sibling_container_for_callee = hserver.use_docker_sibling_containers()
     caller_mount_path, callee_mount_path, mount = get_docker_mount_info(
         is_caller_host, use_sibling_container_for_callee
     )

--- a/helpers/hdocker.py
+++ b/helpers/hdocker.py
@@ -616,7 +616,9 @@ def run_dockerized_prettier(
     )
     # Convert files to Docker paths.
     is_caller_host = not hserver.is_inside_docker()
-    use_sibling_container_for_callee = hserver.use_docker_sibling_containers()
+    # TODO(gp): After fix for CmampTask10710 enable this.
+    # use_sibling_container_for_callee = hserver.use_docker_sibling_containers()
+    use_sibling_container_for_callee = True
     caller_mount_path, callee_mount_path, mount = get_docker_mount_info(
         is_caller_host, use_sibling_container_for_callee
     )
@@ -1045,7 +1047,9 @@ def run_dockerized_markdown_toc(
     )
     # Convert files to Docker paths.
     is_caller_host = not hserver.is_inside_docker()
-    use_sibling_container_for_callee = hserver.use_docker_sibling_containers()
+    # TODO(gp): After fix for CmampTask10710 enable this.
+    # use_sibling_container_for_callee = hserver.use_docker_sibling_containers()
+    use_sibling_container_for_callee = True
     caller_mount_path, callee_mount_path, mount = get_docker_mount_info(
         is_caller_host, use_sibling_container_for_callee
     )

--- a/linters/test/outcomes/Test_linter_py1.test_linter_md1/output/test.txt
+++ b/linters/test/outcomes/Test_linter_py1.test_linter_md1/output/test.txt
@@ -3,13 +3,13 @@
 HH:MM:SS - [36mINFO [0m base.py _run_linter:{LINE_NUM}            Using num_threads='serial' since there is only one file to lint
 HH:MM:SS - [36mINFO [0m base.py _lint:{LINE_NUM}
 Linting file: '$GIT_ROOT/linters/test/outcomes/Test_linter_py1.test_linter_md1/tmp.scratch/hello.md'
-HH:MM:SS - [41mWARN [0m amp_check_md_reference.py check_file_reference:{LINE_NUM}      README.md not found. Skipping check for '$GIT_ROOT/linters/test/outcomes/Test_linter_py1.test_linter_md1/tmp.scratch/hello.md'
 ////////////////////////////////////////////////////////////////////////////////
 linter_warnings.txt
 ////////////////////////////////////////////////////////////////////////////////
 file_paths=1 ['$GIT_ROOT/linters/test/outcomes/Test_linter_py1.test_linter_md1/tmp.scratch/hello.md']
 actions=24 ['add_python_init_files', 'add_toc_to_notebook', 'fix_md_links', 'lint_md', 'check_md_toc_headers', 'autoflake', 'fix_whitespaces', 'doc_formatter', 'isort', 'class_method_order', 'normalize_imports', 'format_separating_line', 'add_class_frames', 'black', 'process_jupytext', 'check_file_size', 'check_filename', 'check_merge_conflict', 'check_import', 'warn_incorrectly_formatted_todo', 'check_md_reference', 'flake8', 'pylint', 'mypy']
 ////////////////////////////////////////////////////////////////////////////////
+$GIT_ROOT/linters/test/outcomes/Test_linter_py1.test_linter_md1/tmp.scratch/hello.md: '$GIT_ROOT/linters/test/outcomes/Test_linter_py1.test_linter_md1/tmp.scratch/hello.md' is not referenced in README.md [check_md_reference]
 HH:MM:SS - [36mINFO [0m hdbg.py init_logger:{LINE_NUM}                               > cmd='./dev_scripts_helpers/documentation/lint_notes.py -i $GIT_ROOT/linters/test/outcomes/Test_linter_py1.test_linter_md1/tmp.scratch/hello.md --in_place' [lint_md]
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/linters/test/test_amp_dev_scripts.py
+++ b/linters/test/test_amp_dev_scripts.py
@@ -97,7 +97,11 @@ class Test_linter_py1(hunitest.TestCase):
 
     # #########################################################################
 
+    # TODO(heanh): Remove the skip when the dockerized executable issue is resolved.
     @pytest.mark.slow("About 6 sec")
+    @pytest.mark.skip(
+        "Skip due to issue related to dockerized executable. See HelpersTask553."
+    )
     def test_linter_md1(self) -> None:
         """
         Run Linter as executable on Markdown.

--- a/linters/test/test_amp_dev_scripts.py
+++ b/linters/test/test_amp_dev_scripts.py
@@ -97,11 +97,7 @@ class Test_linter_py1(hunitest.TestCase):
 
     # #########################################################################
 
-    # TODO(heanh): Remove the skip when the dockerized executable issue is resolved.
     @pytest.mark.slow("About 6 sec")
-    @pytest.mark.skip(
-        "Skip due to issue related to dockerized executable. See HelpersTask553."
-    )
     def test_linter_md1(self) -> None:
         """
         Run Linter as executable on Markdown.


### PR DESCRIPTION
Task #553

- The issue is related to the mounting path of the source dir in the dockerized executables. It looks like we can't use the sibling container approach here. The children container approach should work. We can use the `hserver.use_docker_sibling_containers()` to check if sibling container is supported.