### PR TITLE
Cmamptask11907_disable_test_cmamp_ci

### DIFF
--- a/helpers/test/test_repo_config_amp.py
+++ b/helpers/test/test_repo_config_amp.py
@@ -228,6 +228,7 @@ class TestRepoConfig_Amp_signature1(hunitest.TestCase):
         skip_secrets_vars = True
         hunteuti.check_env_to_str(self, exp, skip_secrets_vars=skip_secrets_vars)
 
+    @pytest.mark.skip(reason="See CmampTask11907")
     @pytest.mark.skipif(
         not hrecouti.get_repo_config().get_name() == "//cmamp",
         reason="Run only in //cmamp",


### PR DESCRIPTION
[#11907](https://github.com/causify-ai/cmamp/issues/11907)

- disable FAILED `helpers/test/test_repo_config_amp.py::TestRepoConfig_Amp_signature1::test_cmamp_ci` to unblock #11789
