### PR TITLE
HelpersTask568_moving_line_in_golden_output

### DIFF
--- a/linters/test/outcomes/Test_linter_py1.test_linter_md1/output/test.txt
+++ b/linters/test/outcomes/Test_linter_py1.test_linter_md1/output/test.txt
@@ -9,7 +9,6 @@ linter_warnings.txt
 file_paths=1 ['$GIT_ROOT/linters/test/outcomes/Test_linter_py1.test_linter_md1/tmp.scratch/hello.md']
 actions=24 ['add_python_init_files', 'add_toc_to_notebook', 'fix_md_links', 'lint_md', 'check_md_toc_headers', 'autoflake', 'fix_whitespaces', 'doc_formatter', 'isort', 'class_method_order', 'normalize_imports', 'format_separating_line', 'add_class_frames', 'black', 'process_jupytext', 'check_file_size', 'check_filename', 'check_merge_conflict', 'check_import', 'warn_incorrectly_formatted_todo', 'check_md_reference', 'flake8', 'pylint', 'mypy']
 ////////////////////////////////////////////////////////////////////////////////
-$GIT_ROOT/linters/test/outcomes/Test_linter_py1.test_linter_md1/tmp.scratch/hello.md: '$GIT_ROOT/linters/test/outcomes/Test_linter_py1.test_linter_md1/tmp.scratch/hello.md' is not referenced in README.md [check_md_reference]
 HH:MM:SS - [36mINFO [0m hdbg.py init_logger:{LINE_NUM}                               > cmd='./dev_scripts_helpers/documentation/lint_notes.py -i $GIT_ROOT/linters/test/outcomes/Test_linter_py1.test_linter_md1/tmp.scratch/hello.md --in_place' [lint_md]
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/linters/test/outcomes/Test_linter_py1.test_linter_md2/output/test.txt
+++ b/linters/test/outcomes/Test_linter_py1.test_linter_md2/output/test.txt
@@ -9,7 +9,6 @@ linter_warnings.txt
 file_paths=1 ['$GIT_ROOT/linters/test/outcomes/Test_linter_py1.test_linter_md2/tmp.scratch/hello.md']
 actions=24 ['add_python_init_files', 'add_toc_to_notebook', 'fix_md_links', 'lint_md', 'check_md_toc_headers', 'autoflake', 'fix_whitespaces', 'doc_formatter', 'isort', 'class_method_order', 'normalize_imports', 'format_separating_line', 'add_class_frames', 'black', 'process_jupytext', 'check_file_size', 'check_filename', 'check_merge_conflict', 'check_import', 'warn_incorrectly_formatted_todo', 'check_md_reference', 'flake8', 'pylint', 'mypy']
 ////////////////////////////////////////////////////////////////////////////////
-$GIT_ROOT/linters/test/outcomes/Test_linter_py1.test_linter_md2/tmp.scratch/hello.md: '$GIT_ROOT/linters/test/outcomes/Test_linter_py1.test_linter_md2/tmp.scratch/hello.md' is not referenced in README.md [check_md_reference]
 HH:MM:SS - [36mINFO [0m hdbg.py init_logger:{LINE_NUM}                               > cmd='./dev_scripts_helpers/documentation/lint_notes.py -i $GIT_ROOT/linters/test/outcomes/Test_linter_py1.test_linter_md2/tmp.scratch/hello.md --in_place' [lint_md]
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/linters/test/test_amp_dev_scripts.py
+++ b/linters/test/test_amp_dev_scripts.py
@@ -117,7 +117,7 @@ class Test_linter_py1(hunitest.TestCase):
         file_name = "hello.md"
         as_system_call = True
         output = self.run_linter(txt, file_name, as_system_call)
-        # Remove the line:
+        # Remove the lines:
         # '12-16_14:59 ^[[33mWARNING^[[0m: _refresh_toc   :138 : No tags for table'.
         # '$GIT_ROOT/linters/test/outcomes/.../hello.md: is not referenced in README.md'.
         log_filters = ["No tags for table", "is not referenced in README.md"]
@@ -142,7 +142,7 @@ nothing should be changed
         file_name = "hello.md"
         as_system_call = True
         output = self.run_linter(txt, file_name, as_system_call)
-        # Remove the line:
+        # Remove the lines:
         # '12-16_14:59 ^[[33mWARNING^[[0m: _refresh_toc   :138 : No tags for table'.
         # '$GIT_ROOT/linters/test/outcomes/.../hello.md: is not referenced in README.md'.
         log_filters = ["No tags for table", "is not referenced in README.md"]

--- a/linters/test/test_amp_dev_scripts.py
+++ b/linters/test/test_amp_dev_scripts.py
@@ -98,11 +98,7 @@ class Test_linter_py1(hunitest.TestCase):
 
     # #########################################################################
 
-    # TODO(heanh): Remove the skip when the dockerized executable issue is resolved.
     @pytest.mark.slow("About 6 sec")
-    @pytest.mark.skip(
-        "Skip due to issue related to dockerized executable. See HelpersTask553."
-    )
     def test_linter_md1(self) -> None:
         """
         Run Linter as executable on Markdown.
@@ -122,16 +118,15 @@ class Test_linter_py1(hunitest.TestCase):
         as_system_call = True
         output = self.run_linter(txt, file_name, as_system_call)
         # Remove the line:
-        # '12-16_14:59 ^[[33mWARNING^[[0m: _refresh_toc   :138 : No tags for table'
-        output = hunitest.filter_text("No tags for table", output)
+        # '12-16_14:59 ^[[33mWARNING^[[0m: _refresh_toc   :138 : No tags for table'.
+        # '$GIT_ROOT/linters/test/outcomes/.../hello.md: is not referenced in README.md'.
+        log_filters = ["No tags for table", "is not referenced in README.md"]
+        for log_filter in log_filters:
+            output = hunitest.filter_text(log_filter, output)
         # Check.
         self.check_string(output, purify_text=True)
 
-    # TODO(heanh): Remove the skip when the dockerized executable issue is resolved.
     @pytest.mark.slow("About 6 sec")
-    @pytest.mark.skip(
-        "Skip due to issue related to dockerized executable. See HelpersTask553."
-    )
     def test_linter_md2(self) -> None:
         """
         Run Linter as executable on Markdown file with a fenced block.
@@ -148,8 +143,11 @@ nothing should be changed
         as_system_call = True
         output = self.run_linter(txt, file_name, as_system_call)
         # Remove the line:
-        # '12-16_14:59 ^[[33mWARNING^[[0m: _refresh_toc   :138 : No tags for table'
-        output = hunitest.filter_text("No tags for table", output)
+        # '12-16_14:59 ^[[33mWARNING^[[0m: _refresh_toc   :138 : No tags for table'.
+        # '$GIT_ROOT/linters/test/outcomes/.../hello.md: is not referenced in README.md'.
+        log_filters = ["No tags for table", "is not referenced in README.md"]
+        for log_filter in log_filters:
+            output = hunitest.filter_text(log_filter, output)
         # Check.
         self.check_string(output, purify_text=True)
 

--- a/linters/test/test_amp_dev_scripts.py
+++ b/linters/test/test_amp_dev_scripts.py
@@ -98,7 +98,11 @@ class Test_linter_py1(hunitest.TestCase):
 
     # #########################################################################
 
+    # TODO(heanh): Remove the skip when the dockerized executable issue is resolved.
     @pytest.mark.slow("About 6 sec")
+    @pytest.mark.skip(
+        "Skip due to issue related to dockerized executable. See HelpersTask553."
+    )
     def test_linter_md1(self) -> None:
         """
         Run Linter as executable on Markdown.
@@ -126,7 +130,11 @@ class Test_linter_py1(hunitest.TestCase):
         # Check.
         self.check_string(output, purify_text=True)
 
+    # TODO(heanh): Remove the skip when the dockerized executable issue is resolved.
     @pytest.mark.slow("About 6 sec")
+    @pytest.mark.skip(
+        "Skip due to issue related to dockerized executable. See HelpersTask553."
+    )
     def test_linter_md2(self) -> None:
         """
         Run Linter as executable on Markdown file with a fenced block.


### PR DESCRIPTION
Related to #568 

Updated `linters/test/test_amp_dev_scripts.py` to filter out glitchy line for `Test_linter_py1.test_linter_md1()` and `Test_linter_py1.test_linter_md2()`. 

Note: I did not run linter, as it would alter the unit test input python scripts. 