### PR TITLE
HelpersTask596_Links_are_incorrectly_converted_inside_fenced_blocks

### DIFF
--- a/linters/amp_fix_md_links.py
+++ b/linters/amp_fix_md_links.py
@@ -30,7 +30,7 @@ FILE_PATH_REGEX = r"\.{0,2}\w*\/\S+\.[\w\.]+"
 HTML_LINK_REGEX = r'(<a href=".*?">.*?</a>)'
 MD_LINK_REGEX = r"\[(.+)\]\(((?!#).*)\)"
 BARE_LINK_REGEX = r"(?<!\[)(?<!\]\()(?<!href=\")([Hh]ttps?://[^\s<>()]+)"
-FENCE_RE = re.compile(r"^\s*(```|~~~)")
+FENCE_REGEX = re.compile(r"^\s*(```|~~~)")
 
 
 def _make_path_absolute(path: str) -> str:
@@ -305,16 +305,16 @@ def fix_links(file_name: str) -> Tuple[List[str], List[str], List[str]]:
     docstring_line_indices = hstring.get_docstring_line_indices(lines)
     updated_lines: List[str] = []
     warnings: List[str] = []
-    inside_fence = False
+    is_inside_fence = False
     for i, line in enumerate(lines, start=1):
         updated_line = line
         # Check if we're entering or exiting a fenced block.
-        if FENCE_RE.match(line):
-            inside_fence = not inside_fence
+        if FENCE_REGEX.match(line):
+            is_inside_fence = not is_inside_fence
             updated_lines.append(updated_line)
             continue
         # Skip processing links in fenced blocks.
-        if inside_fence:
+        if is_inside_fence:
             updated_lines.append(updated_line)
             continue
         # Check the formatting.

--- a/linters/amp_fix_md_links.py
+++ b/linters/amp_fix_md_links.py
@@ -304,8 +304,18 @@ def fix_links(file_name: str) -> Tuple[List[str], List[str], List[str]]:
     docstring_line_indices = hstring.get_docstring_line_indices(lines)
     updated_lines: List[str] = []
     warnings: List[str] = []
+    inside_fence = False
     for i, line in enumerate(lines, start=1):
         updated_line = line
+        # Check if we're entering or exiting a fenced block.
+        if line.strip().startswith("```"):
+            inside_fence = not inside_fence
+            updated_lines.append(updated_line)
+            continue
+        # Skip processing links in fenced blocks.
+        if inside_fence:
+            updated_lines.append(updated_line)
+            continue
         # Check the formatting.
         # HTML-style links.
         html_link_matches = re.findall(HTML_LINK_REGEX, updated_line)

--- a/linters/amp_fix_md_links.py
+++ b/linters/amp_fix_md_links.py
@@ -30,6 +30,7 @@ FILE_PATH_REGEX = r"\.{0,2}\w*\/\S+\.[\w\.]+"
 HTML_LINK_REGEX = r'(<a href=".*?">.*?</a>)'
 MD_LINK_REGEX = r"\[(.+)\]\(((?!#).*)\)"
 BARE_LINK_REGEX = r"(?<!\[)(?<!\]\()(?<!href=\")([Hh]ttps?://[^\s<>()]+)"
+FENCE_RE = re.compile(r"^\s*(```|~~~)")
 
 
 def _make_path_absolute(path: str) -> str:
@@ -308,7 +309,7 @@ def fix_links(file_name: str) -> Tuple[List[str], List[str], List[str]]:
     for i, line in enumerate(lines, start=1):
         updated_line = line
         # Check if we're entering or exiting a fenced block.
-        if line.strip().startswith("```"):
+        if FENCE_RE.match(line):
             inside_fence = not inside_fence
             updated_lines.append(updated_line)
             continue

--- a/linters/amp_fix_md_links.py
+++ b/linters/amp_fix_md_links.py
@@ -308,13 +308,13 @@ def fix_links(file_name: str) -> Tuple[List[str], List[str], List[str]]:
     is_inside_fence = False
     for i, line in enumerate(lines, start=1):
         updated_line = line
-        # Check if we're entering or exiting a fenced block.
         if FENCE_REGEX.match(line):
+            # Check if we're entering or exiting a fenced block.
             is_inside_fence = not is_inside_fence
             updated_lines.append(updated_line)
             continue
-        # Skip processing links in fenced blocks.
         if is_inside_fence:
+            # Skip processing links in fenced blocks.
             updated_lines.append(updated_line)
             continue
         # Check the formatting.

--- a/linters/test/outcomes/Test_fix_links.test11/output/test.txt
+++ b/linters/test/outcomes/Test_fix_links.test11/output/test.txt
@@ -1,0 +1,15 @@
+# linter warnings
+
+
+# linted file
+Links inside fenced block that should not be formatted:
+```
+https://example.com/inside-fenced-block
+http://github.com/user/repo
+```
+
+Another fenced block with different language:
+```python
+url = "https://example.com/python-url"
+response = requests.get("https://api.github.com/users")
+```

--- a/linters/test/test_amp_fix_md_links.py
+++ b/linters/test/test_amp_fix_md_links.py
@@ -401,6 +401,76 @@ class Test_fix_links(hunitest.TestCase):
         ]
         self.assertEqual(expected, actual)
 
+    def test11(self) -> None:
+        """
+        Test that links inside fenced code blocks are not modified.
+        """
+        # Prepare inputs with links both inside and outside fenced blocks
+        text = r"""
+        Regular bare link that should be converted:
+        https://example.com/regular-link
+
+        Links inside fenced code block that should not be converted:
+        ```
+        # Code with URLs
+        https://example.com/inside-code-block
+        http://github.com/user/repo
+
+        def example():
+            # Comment with URL https://example.com/in-comment
+            url = "https://api.example.com/endpoint"
+            return url
+        ```
+
+        Another regular bare link after the code block:
+        https://example.com/another-link
+
+        Another fenced block with different language:
+        ```python
+        # Python code with URLs
+        url = "https://example.com/python-url"
+        response = requests.get("https://api.github.com/users")
+        ```
+
+        Final regular link:
+        https://example.com/final-link
+        """
+        file_name = "test_fenced_blocks.md"
+        file_path = self.write_input_file(text, file_name)
+        # Run.
+        _, actual, _ = lafimdli.fix_links(file_path)
+        # Check
+        expected = [
+            "Regular bare link that should be converted:",
+            "[https://example.com/regular-link](https://example.com/regular-link)",
+            "",
+            "Links inside fenced code block that should not be converted:",
+            "```",
+            "# Code with URLs",
+            "https://example.com/inside-code-block",
+            "http://github.com/user/repo",
+            "",
+            "def example():",
+            "    # Comment with URL https://example.com/in-comment",
+            '    url = "https://api.example.com/endpoint"',
+            "    return url",
+            "```",
+            "",
+            "Another regular bare link after the code block:",
+            "[https://example.com/another-link](https://example.com/another-link)",
+            "",
+            "Another fenced block with different language:",
+            "```python",
+            "# Python code with URLs",
+            'url = "https://example.com/python-url"',
+            'response = requests.get("https://api.github.com/users")',
+            "```",
+            "",
+            "Final regular link:",
+            "[https://example.com/final-link](https://example.com/final-link)",
+        ]
+        self.assertEqual(expected, actual)
+
 
 # #############################################################################
 # Test_make_path_absolute

--- a/linters/test/test_amp_fix_md_links.py
+++ b/linters/test/test_amp_fix_md_links.py
@@ -407,69 +407,25 @@ class Test_fix_links(hunitest.TestCase):
         """
         # Prepare inputs with links both inside and outside fenced blocks
         text = r"""
-        Regular bare link that should be converted:
-        https://example.com/regular-link
-
-        Links inside fenced code block that should not be converted:
+        Links inside fenced block that should not be formatted:
         ```
-        # Code with URLs
-        https://example.com/inside-code-block
+        https://example.com/inside-fenced-block
         http://github.com/user/repo
-
-        def example():
-            # Comment with URL https://example.com/in-comment
-            url = "https://api.example.com/endpoint"
-            return url
         ```
-
-        Another regular bare link after the code block:
-        https://example.com/another-link
 
         Another fenced block with different language:
         ```python
-        # Python code with URLs
         url = "https://example.com/python-url"
         response = requests.get("https://api.github.com/users")
         ```
-
-        Final regular link:
-        https://example.com/final-link
         """
         file_name = "test_fenced_blocks.md"
         file_path = self.write_input_file(text, file_name)
         # Run.
-        _, actual, _ = lafimdli.fix_links(file_path)
-        # Check
-        expected = [
-            "Regular bare link that should be converted:",
-            "[https://example.com/regular-link](https://example.com/regular-link)",
-            "",
-            "Links inside fenced code block that should not be converted:",
-            "```",
-            "# Code with URLs",
-            "https://example.com/inside-code-block",
-            "http://github.com/user/repo",
-            "",
-            "def example():",
-            "    # Comment with URL https://example.com/in-comment",
-            '    url = "https://api.example.com/endpoint"',
-            "    return url",
-            "```",
-            "",
-            "Another regular bare link after the code block:",
-            "[https://example.com/another-link](https://example.com/another-link)",
-            "",
-            "Another fenced block with different language:",
-            "```python",
-            "# Python code with URLs",
-            'url = "https://example.com/python-url"',
-            'response = requests.get("https://api.github.com/users")',
-            "```",
-            "",
-            "Final regular link:",
-            "[https://example.com/final-link](https://example.com/final-link)",
-        ]
-        self.assertEqual(expected, actual)
+        _, updated_lines, out_warnings = lafimdli.fix_links(file_path)
+        # Check.
+        output = _get_output_string(out_warnings, updated_lines)
+        self.check_string(output, purify_text=True)
 
 
 # #############################################################################

--- a/linters/test/test_amp_fix_md_links.py
+++ b/linters/test/test_amp_fix_md_links.py
@@ -405,7 +405,7 @@ class Test_fix_links(hunitest.TestCase):
         """
         Test that links inside fenced code blocks are not modified.
         """
-        # Prepare inputs with links both inside and outside fenced blocks
+        # Prepare inputs.
         text = r"""
         Links inside fenced block that should not be formatted:
         ```


### PR DESCRIPTION
Addressing #596 

* Added `FENCE_RE` regex pattern and `inside_fence` flag to detect ```/~~~ fences.  
* Lines falling between fences are skipped for link/path/figure processing.  
* Added a new test case. 

Would you like me to merge the previous test case to check the bare link formatting and the new test case to check that the bare links inside the fenced blocks have not been modified? 