### PR TITLE
HelpersTask515-replace-cryptokaizen-with-causify-ai-links

### DIFF
--- a/dev_scripts_helpers/cleanup_scripts/HelpersTask515_Replace_cryptokaizen_with_causify-ai_in_links.sh
+++ b/dev_scripts_helpers/cleanup_scripts/HelpersTask515_Replace_cryptokaizen_with_causify-ai_in_links.sh
@@ -1,0 +1,7 @@
+replace_text.py \
+    --old "_ck" \
+    --new "_csfy" 
+
+# replace_text.py \
+#     --old "ck" \
+#     --new "csfy" 


### PR DESCRIPTION
Link to Issue: #515 

Replacing cryptokaizen with causify-ai, ck with csfy and _ck with _csfy.

FYI @sonniki @samarth9008 @gpsaggese 