### PR TITLE
HelpersTask619_Remove_header_level_difference_assertion

### DIFF
--- a/helpers/hmarkdown.py
+++ b/helpers/hmarkdown.py
@@ -404,15 +404,15 @@ def check_header_list(header_list: HeaderList) -> None:
             header_list[0].line_number,
             header_list[0].level,
         )
-    # Check that consecutive elements in the header list differ by at most one
-    # value of level.
+    # Check that headers only increase by at most one level at a time,
+    # but can decrease by multiple levels.
     if len(header_list) > 1:
         for i in range(1, len(header_list)):
             hdbg.dassert_isinstance(header_list[i - 1], HeaderInfo)
             hdbg.dassert_isinstance(header_list[i], HeaderInfo)
-            if abs(header_list[i].level - header_list[i - 1].level) > 1:
+            if header_list[i].level - header_list[i - 1].level > 1:
                 msg = []
-                msg.append("Consecutive headers differ by more than one level:")
+                msg.append("Consecutive headers increase by more than one level:")
                 msg.append(f"  {header_list[i - 1]}")
                 msg.append(f"  {header_list[i]}")
                 msg = "\n".join(msg)


### PR DESCRIPTION
Addressing #619 

Modified the header level validation to allow decreasing by multiple levels but still require increasing by only one level at a time. 

Should we add a test case to verify this?