### PR TITLE
HelpersTask618_Links_formatted_inside_quotation_marks

### DIFF
--- a/linters/amp_fix_md_links.py
+++ b/linters/amp_fix_md_links.py
@@ -29,7 +29,7 @@ FIG_REGEX_2 = r"!\[\w*\]\(\.{0,2}\w*\/\S+?\.(?:jpg|jpeg|png)\)"
 FILE_PATH_REGEX = r"\.{0,2}\w*\/\S+\.[\w\.]+"
 HTML_LINK_REGEX = r'(<a href=".*?">.*?</a>)'
 MD_LINK_REGEX = r"\[(.+)\]\(((?!#).*)\)"
-BARE_LINK_REGEX = r"(?<!\[)(?<!\]\()(?<!href=\")([Hh]ttps?://[^\s<>()]+)"
+BARE_LINK_REGEX = r"(?<!\[)(?<!\]\()(?<!href=\")(?<![\'\"])([Hh]ttps?://[^\s<>()\'\"]+)(?![\'\"])"
 FENCE_REGEX = re.compile(r"^\s*(```|~~~)")
 
 

--- a/linters/test/test_amp_fix_md_links.py
+++ b/linters/test/test_amp_fix_md_links.py
@@ -427,6 +427,33 @@ class Test_fix_links(hunitest.TestCase):
         output = _get_output_string(out_warnings, updated_lines)
         self.check_string(output, purify_text=True)
 
+    def test12(self) -> None:
+        """
+        Test that URLs inside quotation marks are not converted to Markdown-
+        style links.
+        """
+        # Prepare inputs.
+        text = r"""
+        URL in quotation marks: "https://example.com/path".
+
+        Image with URL in src attribute: <img width="505" alt="" src="https://github.com/user/repo/assets/12345/abcdef-ghijk-lmnop" />
+
+        URL in HTML attribute: <div data-url="https://api.example.com/endpoint"></div>
+        """
+        file_name = "test_quoted_urls.md"
+        file_path = self.write_input_file(text, file_name)
+        # Run.
+        _, actual, _ = lafimdli.fix_links(file_path)
+        # Check.
+        expected = [
+            'URL in quotation marks: "https://example.com/path".',
+            "",
+            'Image with URL in src attribute: <img width="505" alt="" src="https://github.com/user/repo/assets/12345/abcdef-ghijk-lmnop" />',
+            "",
+            'URL in HTML attribute: <div data-url="https://api.example.com/endpoint"></div>',
+        ]
+        self.assertEqual(expected, actual)
+
 
 # #############################################################################
 # Test_make_path_absolute


### PR DESCRIPTION
Addressing #618 

Modified the bare link regex pattern to catch URLs inside quotation marks. A test case was added to verify if the modified pattern works.

Note - The modified regex pattern does not match URLs inside single quotes and URLs inside quotation marks starting with text. E.g. `'https://example.com/path'`, `"Word https://example.com/path"`. 

I did a grep and checked if there are any such instances right now in the repo, but there aren't any. If necessary, we can make it robust to the above examples by using a complex regex pattern or a helper function. 