### PR TITLE
HelpersTask615_Come_up_with_a_testing_approach_for_release_flow

### DIFF
--- a/helpers/hunit_test.py
+++ b/helpers/hunit_test.py
@@ -396,7 +396,10 @@ def purify_from_environment(txt: str) -> str:
             pass
     # 2) Remove CSFY_GIT_ROOT_PATH
     val = os.environ.get("CSFY_HOST_GIT_ROOT_PATH")
-    txt = re.sub(val, "$CSFY_HOST_GIT_ROOT_PATH", txt, flags=re.MULTILINE)
+    if val is not None:
+        txt = re.sub(val, "$CSFY_HOST_GIT_ROOT_PATH", txt, flags=re.MULTILINE)
+    else:
+        _LOG.debug("CSFY_HOST_GIT_ROOT_PATH is not set")
     # 3) Replace the path of current working dir with `$PWD`.
     pwd = os.getcwd()
     pattern = re.compile(f"{pwd}{dir_pattern}")

--- a/helpers/test/test_lib_tasks.py
+++ b/helpers/test/test_lib_tasks.py
@@ -67,6 +67,7 @@ class _LibTasksTestCase(hunitest.TestCase):
 # #############################################################################
 
 
+# TODO(gp): Make it public.
 def _build_mock_context_returning_ok() -> invoke.MockContext:
     """
     Build a MockContext catching any command and returning rc=0.
@@ -108,9 +109,6 @@ class _CheckDryRunTestCase(hunitest.TestCase):
         # Check the outcome.
         if check:
             self._check_calls(ctx)
-
-
-# #############################################################################
 
 
 # TODO(gp): We should group the tests by what is tested and not how it's

--- a/helpers/test/test_lib_tasks_docker_release.py
+++ b/helpers/test/test_lib_tasks_docker_release.py
@@ -112,9 +112,8 @@ class TestDockerBuildLocalImage1(hunitest.TestCase):
         mock_ctx = httestlib._build_mock_context_returning_ok()
         test_version = "1.0.0"
         test_base_image = "test-registry.com/test-image"
-        # Call tested function using `.body` to bypass invoke's argument
-        # parsing and run the raw implementation.
-        hltadore.docker_build_local_image.body(
+        # Call tested function .
+        hltadore.docker_build_local_image(
             mock_ctx,
             test_version,
             cache=False,
@@ -194,9 +193,8 @@ class TestDockerBuildLocalImage1(hunitest.TestCase):
         test_version = "1.0.0"
         test_base_image = "test-registry.com/test-image"
         test_multi_arch = "linux/amd64,linux/arm64"
-        # Call tested function using `.body` to bypass invoke's argument
-        # parsing and run the raw implementation.
-        hltadore.docker_build_local_image.body(
+        # Call tested function.
+        hltadore.docker_build_local_image(
             mock_ctx,
             test_version,
             cache=False,

--- a/helpers/test/test_lib_tasks_docker_release.py
+++ b/helpers/test/test_lib_tasks_docker_release.py
@@ -1,0 +1,176 @@
+import logging
+import re
+import unittest.mock as umock
+
+import helpers.hsystem as hsystem
+import helpers.hunit_test as hunitest
+import helpers.lib_tasks_docker_release as hltadore
+
+_LOG = logging.getLogger(__name__)
+
+
+# #############################################################################
+# TestDockerBuildLocalImage1
+# #############################################################################
+
+
+class TestDockerBuildLocalImage1(hunitest.TestCase):
+    """
+    Test suite for docker_build_local_image function.
+
+    This class contains unit tests for both single-architecture and
+    multi-architecture Docker image builds.
+    """
+
+    def setUp(self) -> None:
+        """
+        Set up test environment and initialize all necessary mocks.
+        """
+        # Mock system calls.
+        self.system_patcher = umock.patch("helpers.hsystem.system")
+        self.mock_system = self.system_patcher.start()
+        # Mock run.
+        self.run_patcher = umock.patch("helpers.lib_tasks_utils.run")
+        self.mock_run = self.run_patcher.start()
+        # Mock version validation.
+        self.version_patcher = umock.patch(
+            "helpers.lib_tasks_docker.dassert_is_subsequent_version"
+        )
+        self.mock_version = self.version_patcher.start()
+        # Mock docker login
+        self.docker_login_patcher = umock.patch(
+            "helpers.lib_tasks_docker.docker_login"
+        )
+        self.mock_docker_login = self.docker_login_patcher.start()
+        # Get user name.
+        self.user = hsystem.get_user_name()
+
+    def tearDown(self) -> None:
+        """
+        Clean up test environment.
+
+        This method stops all mocks after each test case.
+        """
+        self.system_patcher.stop()
+        self.run_patcher.stop()
+        self.version_patcher.stop()
+        self.docker_login_patcher.stop()
+
+    def test_docker_build_single_arch(self) -> None:
+        """
+        Test building a local Docker image with single architecture.
+
+        This test verifies that the correct sequence of commands is
+        generated for building a local Docker image with single
+        architecture.
+        """
+        # Prepare inputs.
+        mock_ctx = umock.MagicMock()
+        test_version = "1.0.0"
+        test_base_image = "test-registry.com/test-image"
+        test_multi_arch = ""
+        # Call tested function.
+        hltadore.docker_build_local_image.body(
+            ctx=mock_ctx,
+            version=test_version,
+            base_image=test_base_image,
+            multi_arch=test_multi_arch,
+            poetry_mode="update",
+            cache=False,
+        )
+        # Extract the command argument from the call.
+        actual_cmds = [call[0][1] for call in self.mock_run.call_args_list]
+        # Check output.
+        expected_cmds = [
+            "cp -f devops/docker_build/dockerignore.dev .dockerignore",
+            "tar -czh . | DOCKER_BUILDKIT=0 time docker build "
+            " --no-cache "
+            " --build-arg AM_CONTAINER_VERSION=1.0.0 "
+            " --build-arg INSTALL_DIND=True "
+            " --build-arg POETRY_MODE=update "
+            " --build-arg CLEAN_UP_INSTALLATION=True "
+            f" --tag {test_base_image}:local-{self.user}-1.0.0 "
+            " --file devops/docker_build/dev.Dockerfile -",
+            "invoke docker_cmd  "
+            "--stage local "
+            f"--version {test_version} "
+            f"--cmd 'cp -f /install/poetry.lock.out /install/pip_list.txt .' --skip-pull",
+            "cp -f poetry.lock.out ./devops/docker_build/poetry.lock",
+            "cp -f pip_list.txt ./devops/docker_build/pip_list.txt",
+            f"docker image ls {test_base_image}:local-{self.user}-1.0.0",
+        ]
+        # Normalize both expected and actual commands.
+        expected = [self._normalize_command(cmd) for cmd in expected_cmds]
+        actual = [self._normalize_command(cmd) for cmd in actual_cmds]
+        self.assertEqual(expected, actual)
+
+    def test_docker_build_multi_arch(self) -> None:
+        """
+        Test building a local Docker image with multiple architectures.
+
+        This test verifies that the correct sequence of commands is
+        generated for building a local Docker image with multiple
+        architectures.
+        """
+        # Prepare inputs.
+        mock_ctx = umock.MagicMock()
+        test_version = "1.0.0"
+        test_base_image = "test-registry.com/test-image"
+        test_multi_arch = "linux/amd64,linux/arm64"
+        # Call tested function.
+        hltadore.docker_build_local_image.body(
+            ctx=mock_ctx,
+            version=test_version,
+            base_image=test_base_image,
+            multi_arch=test_multi_arch,
+            poetry_mode="update",
+            cache=False,
+        )
+        # Extract the command argument from the call.
+        actual_cmds = [call[0][1] for call in self.mock_run.call_args_list]
+        # Check output.
+        expected_cmds = [
+            "cp -f devops/docker_build/dockerignore.dev .dockerignore",
+            "docker buildx create --name multiarch_builder --driver docker-container --bootstrap && docker buildx use multiarch_builder",
+            "tar -czh . | DOCKER_BUILDKIT=0 time docker buildx build "
+            " --no-cache "
+            " --push --platform linux/amd64,linux/arm64 "
+            " --build-arg AM_CONTAINER_VERSION=1.0.0 "
+            " --build-arg INSTALL_DIND=True "
+            " --build-arg POETRY_MODE=update "
+            " --build-arg CLEAN_UP_INSTALLATION=True "
+            f" --tag {test_base_image}:local-{self.user}-1.0.0 "
+            " --file devops/docker_build/dev.Dockerfile -",
+            f"docker pull {test_base_image}:local-{self.user}-1.0.0",
+            "invoke docker_cmd  "
+            "--stage local "
+            f"--version {test_version} "
+            f"--cmd 'cp -f /install/poetry.lock.out /install/pip_list.txt .' --skip-pull",
+            "cp -f poetry.lock.out ./devops/docker_build/poetry.lock",
+            "cp -f pip_list.txt ./devops/docker_build/pip_list.txt",
+            f"docker image ls {test_base_image}:local-{self.user}-1.0.0",
+        ]
+        # Normalize both expected and actual commands.
+        expected = [self._normalize_command(cmd) for cmd in expected_cmds]
+        actual = [self._normalize_command(cmd) for cmd in actual_cmds]
+        self.assertEqual(expected, actual)
+
+    def _normalize_command(self, cmd: str) -> str:
+        """
+        Normalize a command string by removing extra whitespace and line
+        continuations.
+
+        :param cmd: command string to normalize
+        :return: normalized command string
+        """
+        # Replace line continuation backslashes with spaces.
+        cmd = re.sub(r"\\\s*\n\s*", " ", cmd)
+        # Remove all extra whitespaces.
+        cmd = re.sub(r"\s+", " ", cmd)
+        # Remove spaces around special characters.
+        chars_to_normalize = ["=", ",", "|"]
+        escaped_chars = "".join(re.escape(ch) for ch in chars_to_normalize)
+        cmd = re.sub(rf"\s*([{escaped_chars}])\s*", r"\1", cmd)
+        # Remove leading/trailing whitespace.
+        cmd = cmd.strip()
+        return cmd

--- a/helpers/test/test_lib_tasks_docker_release.py
+++ b/helpers/test/test_lib_tasks_docker_release.py
@@ -1,9 +1,7 @@
 import logging
-import re
 import unittest.mock as umock
-from typing import List, Tuple
+from typing import List
 
-import helpers.hprint as hprint
 import helpers.hsystem as hsystem
 import helpers.hunit_test as hunitest
 import helpers.lib_tasks_docker_release as hltadore
@@ -12,51 +10,28 @@ import helpers.test.test_lib_tasks as httestlib
 _LOG = logging.getLogger(__name__)
 
 
-def _normalize_command(cmd: str) -> str:
-    """
-    Normalize a command string by removing line continuations and spaces around
-    special characters.
-
-    :param cmd: command string to normalize
-    :return: normalized command string
-    """
-    cmd = re.sub(r"\\\s*\n\s*", " ", cmd)
-    chars_to_normalize = ["=", ",", "|"]
-    escaped_chars = "".join(re.escape(ch) for ch in chars_to_normalize)
-    cmd = re.sub(rf"\s*([{escaped_chars}])\s*", r"\1", cmd)
-    return cmd
-
-
-def _convert_commands_to_strings(
-    actual_cmds: List[str], expected_cmds: List[str]
-) -> Tuple[str, str]:
-    """
-    Convert a list of commands to strings and normalize them.
-
-    :param actual_cmds: list of actual command strings
-    :param expected_cmds: list of expected command strings
-    :return: normalized actual commands string and normalized expected
-        commands string
-    """
-    # Normalize each command in both lists.
-    actual_normalized = [_normalize_command(cmd) for cmd in actual_cmds]
-    expected_normalized = [_normalize_command(cmd) for cmd in expected_cmds]
-    # Convert to strings.
-    actual_str = "\n".join(actual_normalized)
-    expected_str = "\n".join(expected_normalized)
-    return actual_str, expected_str
-
-
 def _extract_commands_from_call(calls: List[umock._Call]) -> List[str]:
     """
     Extract command strings from a list of mock call arguments.
+
+    Example:
+        calls = [
+            (
+                # args tuple: (context, command)
+                (mock_ctx, "docker build --no-cache image1"),
+                # kwargs dictionary
+                {"pty": True}
+            )
+        ]
+        After extraction:
+        ["docker build --no-cache image1"]
 
     :param calls: list of mock call objects containing (args, kwargs)
     :return: list of command strings
     """
     # Each mock call is a (args, kwargs) tuple, extract the command string
     # from args[1] in each call.
-    call_list = [call[0][1] for call in calls]
+    call_list = [args_[1] for args_, kwargs_ in calls]
     return call_list
 
 
@@ -171,63 +146,36 @@ class TestDockerBuildLocalImage1(hunitest.TestCase):
             multi_arch=test_multi_arch,
         )
         actual_cmds = _extract_commands_from_call(self.mock_run.call_args_list)
-        # Check buildx setup and build commands.
-        actual_build_cmds = actual_cmds[:3]
-        expected_build_cmds = [
-            "cp -f devops/docker_build/dockerignore.dev .dockerignore",
-            "docker buildx create --name multiarch_builder --driver docker-container --bootstrap && docker buildx use multiarch_builder",
-            "tar -czh . | DOCKER_BUILDKIT=0 time docker buildx build "
-            " --no-cache "
-            " --push --platform linux/amd64,linux/arm64 "
-            " --build-arg AM_CONTAINER_VERSION=1.0.0 "
-            " --build-arg INSTALL_DIND=True "
-            " --build-arg POETRY_MODE=update "
-            " --build-arg CLEAN_UP_INSTALLATION=True "
-            f" --tag {test_base_image}:local-{self.user}-1.0.0 "
-            " --file devops/docker_build/dev.Dockerfile -",
-        ]
-        actual_build, expected_build = _convert_commands_to_strings(
-            actual_build_cmds, expected_build_cmds
-        )
+        actual_cmds = "\n".join(actual_cmds)
+        # The output is a list of strings, each representing a command.
+        exp = r"""
+        cp -f devops/docker_build/dockerignore.dev .dockerignore
+        docker buildx create \
+            --name multiarch_builder \
+            --driver docker-container \
+            --bootstrap \
+            && \
+            docker buildx use multiarch_builder
+        tar -czh . | DOCKER_BUILDKIT=0 \
+            time \
+            docker buildx build \
+            --no-cache \
+            --push \
+            --platform linux/amd64,linux/arm64 \
+            --build-arg AM_CONTAINER_VERSION=1.0.0 --build-arg INSTALL_DIND=True --build-arg POETRY_MODE=update --build-arg CLEAN_UP_INSTALLATION=True \
+            --tag test-registry.com/test-image:local-$USER_NAME-1.0.0 \
+            --file devops/docker_build/dev.Dockerfile \
+            -
+        docker pull test-registry.com/test-image:local-$USER_NAME-1.0.0
+        invoke docker_cmd --stage local --version 1.0.0 --cmd 'cp -f /install/poetry.lock.out /install/pip_list.txt .' --skip-pull
+        cp -f poetry.lock.out ./devops/docker_build/poetry.lock
+        cp -f pip_list.txt ./devops/docker_build/pip_list.txt
+        docker image ls test-registry.com/test-image:local-$USER_NAME-1.0.0
+        """
         self.assert_equal(
-            actual_build,
-            expected_build,
-            fuzzy_match=True,
-            remove_lead_trail_empty_lines=True,
-            dedent=True,
-        )
-        # Check pull and poetry file commands.
-        actual_poetry_cmds = actual_cmds[3:7]
-        expected_poetry_cmds = [
-            f"docker pull {test_base_image}:local-{self.user}-1.0.0",
-            "invoke docker_cmd  "
-            "--stage local "
-            f"--version {test_version} "
-            f"--cmd 'cp -f /install/poetry.lock.out /install/pip_list.txt .' --skip-pull",
-            "cp -f poetry.lock.out ./devops/docker_build/poetry.lock",
-            "cp -f pip_list.txt ./devops/docker_build/pip_list.txt",
-        ]
-        actual_poetry, expected_poetry = _convert_commands_to_strings(
-            actual_poetry_cmds, expected_poetry_cmds
-        )
-        self.assert_equal(
-            actual_poetry,
-            expected_poetry,
-            fuzzy_match=True,
-            remove_lead_trail_empty_lines=True,
-            dedent=True,
-        )
-        # Check list images command.
-        actual_list_cmd = actual_cmds[7]
-        expected_list_cmd = (
-            f"docker image ls {test_base_image}:local-{self.user}-1.0.0"
-        )
-        actual_list, expected_list = _convert_commands_to_strings(
-            actual_list_cmd, expected_list_cmd
-        )
-        self.assert_equal(
-            actual_list,
-            expected_list,
+            actual_cmds,
+            exp,
+            purify_text=True,
             fuzzy_match=True,
             remove_lead_trail_empty_lines=True,
             dedent=True,

--- a/helpers/test/test_lib_tasks_docker_release.py
+++ b/helpers/test/test_lib_tasks_docker_release.py
@@ -88,7 +88,7 @@ class TestDockerBuildLocalImage1(hunitest.TestCase):
         mock_ctx = httestlib._build_mock_context_returning_ok()
         test_version = "1.0.0"
         test_base_image = "test-registry.com/test-image"
-        # Call tested function .
+        # Call tested function.
         hltadore.docker_build_local_image(
             mock_ctx,
             test_version,
@@ -114,6 +114,7 @@ class TestDockerBuildLocalImage1(hunitest.TestCase):
         cp -f pip_list.txt ./devops/docker_build/pip_list.txt
         docker image ls test-registry.com/test-image:local-$USER_NAME-1.0.0
         """
+        # Check output.
         self.assert_equal(
             actual_cmds,
             exp,
@@ -172,6 +173,7 @@ class TestDockerBuildLocalImage1(hunitest.TestCase):
         cp -f pip_list.txt ./devops/docker_build/pip_list.txt
         docker image ls test-registry.com/test-image:local-$USER_NAME-1.0.0
         """
+        # Check output.
         self.assert_equal(
             actual_cmds,
             exp,

--- a/helpers/test/test_lib_tasks_docker_release.py
+++ b/helpers/test/test_lib_tasks_docker_release.py
@@ -10,7 +10,7 @@ import helpers.lib_tasks_docker_release as hltadore
 _LOG = logging.getLogger(__name__)
 
 
-def normalize_command(cmd: str) -> str:
+def _normalize_command(cmd: str) -> str:
     """
     Normalize a command string by removing line continuations and spaces around
     special characters.
@@ -25,7 +25,7 @@ def normalize_command(cmd: str) -> str:
     return cmd
 
 
-def convert_commands_to_strings(
+def _convert_commands_to_strings(
     actual_cmds: List[str], expected_cmds: List[str]
 ) -> Tuple[str, str]:
     """
@@ -37,8 +37,8 @@ def convert_commands_to_strings(
         commands string
     """
     # Normalize each command in both lists.
-    actual_normalized = [normalize_command(cmd) for cmd in actual_cmds]
-    expected_normalized = [normalize_command(cmd) for cmd in expected_cmds]
+    actual_normalized = [_normalize_command(cmd) for cmd in actual_cmds]
+    expected_normalized = [_normalize_command(cmd) for cmd in expected_cmds]
     # Convert to strings.
     actual_str = "\n".join(actual_normalized)
     expected_str = "\n".join(expected_normalized)
@@ -129,7 +129,9 @@ class TestDockerBuildLocalImage1(hunitest.TestCase):
             f"docker image ls {test_base_image}:local-{self.user}-1.0.0",
         ]
         # Normalize and convert both command lists to strings.
-        actual, expected = convert_commands_to_strings(actual_cmds, expected_cmds)
+        actual, expected = _convert_commands_to_strings(
+            actual_cmds, expected_cmds
+        )
         self.assert_equal(
             actual,
             expected,
@@ -186,7 +188,9 @@ class TestDockerBuildLocalImage1(hunitest.TestCase):
             f"docker image ls {test_base_image}:local-{self.user}-1.0.0",
         ]
         # Normalize and convert both command lists to strings.
-        actual, expected = convert_commands_to_strings(actual_cmds, expected_cmds)
+        actual, expected = _convert_commands_to_strings(
+            actual_cmds, expected_cmds
+        )
         self.assert_equal(
             actual,
             expected,

--- a/helpers/test/test_lib_tasks_docker_release.py
+++ b/helpers/test/test_lib_tasks_docker_release.py
@@ -15,12 +15,6 @@ _LOG = logging.getLogger(__name__)
 
 
 class TestDockerBuildLocalImage1(hunitest.TestCase):
-    """
-    Test suite for docker_build_local_image function.
-
-    This class contains unit tests for both single-architecture and
-    multi-architecture Docker image builds.
-    """
 
     def setUp(self) -> None:
         """
@@ -37,19 +31,16 @@ class TestDockerBuildLocalImage1(hunitest.TestCase):
             "helpers.lib_tasks_docker.dassert_is_subsequent_version"
         )
         self.mock_version = self.version_patcher.start()
-        # Mock docker login
+        # Mock docker login.
         self.docker_login_patcher = umock.patch(
             "helpers.lib_tasks_docker.docker_login"
         )
         self.mock_docker_login = self.docker_login_patcher.start()
-        # Get user name.
         self.user = hsystem.get_user_name()
 
     def tearDown(self) -> None:
         """
-        Clean up test environment.
-
-        This method stops all mocks after each test case.
+        Clean up test environment by stopping all mocks after each test case.
         """
         self.system_patcher.stop()
         self.run_patcher.stop()
@@ -78,7 +69,7 @@ class TestDockerBuildLocalImage1(hunitest.TestCase):
             poetry_mode="update",
             cache=False,
         )
-        # Extract the command argument from the call.
+        # Extract the command arguments from the call.
         actual_cmds = [call[0][1] for call in self.mock_run.call_args_list]
         # Check output.
         expected_cmds = [
@@ -102,7 +93,11 @@ class TestDockerBuildLocalImage1(hunitest.TestCase):
         # Normalize both expected and actual commands.
         expected = [self._normalize_command(cmd) for cmd in expected_cmds]
         actual = [self._normalize_command(cmd) for cmd in actual_cmds]
-        self.assertEqual(expected, actual)
+        self.assertEqual(
+            expected,
+            actual,
+            f"Expected commands: {expected}\nActual commands: {actual}",
+        )
 
     def test_docker_build_multi_arch(self) -> None:
         """
@@ -126,7 +121,7 @@ class TestDockerBuildLocalImage1(hunitest.TestCase):
             poetry_mode="update",
             cache=False,
         )
-        # Extract the command argument from the call.
+        # Extract the command arguments from the call.
         actual_cmds = [call[0][1] for call in self.mock_run.call_args_list]
         # Check output.
         expected_cmds = [
@@ -153,11 +148,15 @@ class TestDockerBuildLocalImage1(hunitest.TestCase):
         # Normalize both expected and actual commands.
         expected = [self._normalize_command(cmd) for cmd in expected_cmds]
         actual = [self._normalize_command(cmd) for cmd in actual_cmds]
-        self.assertEqual(expected, actual)
+        self.assertEqual(
+            expected,
+            actual,
+            f"Expected commands: {expected}\nActual commands: {actual}",
+        )
 
     def _normalize_command(self, cmd: str) -> str:
         """
-        Normalize a command string by removing extra whitespace and line
+        Normalize a command string by removing whitespace and line
         continuations.
 
         :param cmd: command string to normalize


### PR DESCRIPTION
Added unit tests for `docker_build_local_image` (both single arch and multi-arch) (#615)

- Added unittest with mocks to verify Docker build command sequences
- Tests both single and multi-architecture build flows
- Includes assertion error messages with actual and expected command comparison for debugging