### PR TITLE
CMTask12257: Remove git root assertion

### DIFF
--- a/dev_scripts_helpers/thin_client/thin_client_utils.sh
+++ b/dev_scripts_helpers/thin_client/thin_client_utils.sh
@@ -236,7 +236,9 @@ set_path() {
     #
     export PATH=$(pwd):$PATH
     dtrace "GIT_ROOT=$GIT_ROOT"
-    dassert_var_defined "GIT_ROOT"
+    # 
+    # TODO(gp): Enable this as part of HelpersTask12257.
+    # dassert_var_defined "GIT_ROOT"
     #
     export PATH=$GIT_ROOT_DIR:$PATH
     # Avoid ./.mypy_cache/3.12/app/dev_scripts_helpers


### PR DESCRIPTION
[#12257](https://github.com/causify-ai/cmamp/issues/12257)

Removed the git root assertion from thin client script.