### PR TITLE
HelpersTask903_Improve_modify_header_level

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,12 @@
     "allow": [
       "Bash(find:*)",
       "Bash(invoke --list)",
-      "Bash(grep:*)"
+      "Bash(grep:*)",
+      "WebFetch(domain:github.com)",
+      "Bash(python -m mypy:*)",
+      "Bash(python:*)",
+      "Bash(invoke git_branch_create -i 903)",
+      "Bash(gh pr create:*)"
     ],
     "deny": []
   }

--- a/dev_scripts_helpers/documentation/transform_notes.py
+++ b/dev_scripts_helpers/documentation/transform_notes.py
@@ -91,7 +91,10 @@ def _main(parser: argparse.ArgumentParser) -> None:
     elif cmd == "format_headers":
         hmarkdo.format_headers(in_file_name, out_file_name, max_lev)
     elif cmd == "increase_headers_level":
-        hmarkdo.modify_header_level(in_file_name, out_file_name, mode="increase")
+        txt = hparser.read_file(in_file_name)
+        txt = "\n".join(txt)
+        modified_txt = hmarkdo.modify_header_level(txt, mode="increase")
+        hparser.write_file(modified_txt.split("\n"), out_file_name)
     else:
         # Read the input.
         txt = hparser.read_file(in_file_name)

--- a/helpers/hmarkdown.py
+++ b/helpers/hmarkdown.py
@@ -889,6 +889,12 @@ def parse_rules_from_txt(txt: str) -> List[str]:
       first-level items.
 
     :param txt: text to process
+        ```
+        - Item 1
+        - Item 2
+           - Item 3
+        - Item 4
+        ```
     :return: extracted bullet points, e.g.,
     """
     lines = txt.split("\n")
@@ -1006,7 +1012,6 @@ def modify_header_level(input_text: str, mode: str) -> str:
     :param mode: indicates the increase or decrease of the header level
     :return: the modified text with header levels adjusted
     """
-    lines = input_text.split("\n")
     #
     txt_tmp = []
     if mode == "increase":
@@ -1015,6 +1020,7 @@ def modify_header_level(input_text: str, mode: str) -> str:
         mode_level = -1
     else:
         raise ValueError(f"Unsupported mode='{mode}'")
+    lines = input_text.split("\n")
     for line in lines:
         # TODO(gp): Use the iterator.
         line = line.rstrip(r"\n")

--- a/helpers/hmarkdown.py
+++ b/helpers/hmarkdown.py
@@ -414,7 +414,14 @@ class HeaderInfo:
         self.level = level
         #
         hdbg.dassert_isinstance(description, str)
-        hdbg.dassert_ne(description, "", "Invalid HeaderInfo: %s, %s, %s", level, description, line_number)
+        hdbg.dassert_ne(
+            description,
+            "",
+            "Invalid HeaderInfo: %s, %s, %s",
+            level,
+            description,
+            line_number,
+        )
         self.description = description
         #
         hdbg.dassert_isinstance(line_number, int)
@@ -486,9 +493,7 @@ def sanity_check_header_list(header_list: HeaderList) -> None:
             hdbg.dassert_isinstance(header_list[i], HeaderInfo)
             if header_list[i].level - header_list[i - 1].level > 1:
                 msg = []
-                msg.append(
-                    "Consecutive headers increase by more than one level:"
-                )
+                msg.append("Consecutive headers increase by more than one level:")
                 msg.append(f"  {header_list[i - 1]}")
                 msg.append(f"  {header_list[i]}")
                 msg = "\n".join(msg)
@@ -536,7 +541,7 @@ def extract_headers_from_markdown(
 
 
 def extract_slides_from_markdown(
-    txt: str, 
+    txt: str,
 ) -> HeaderList:
     """
     Extract slides (i.e., sections prepended by `*`) from Markdown file and
@@ -884,12 +889,6 @@ def parse_rules_from_txt(txt: str) -> List[str]:
       first-level items.
 
     :param txt: text to process
-        ```
-        - Item 1
-        - Item 2
-           - Item 3
-        - Item 4
-        ```
     :return: extracted bullet points, e.g.,
     """
     lines = txt.split("\n")
@@ -999,18 +998,15 @@ def format_headers(in_file_name: str, out_file_name: str, max_lev: int) -> None:
     hparser.write_file(txt_tmp, out_file_name)
 
 
-def modify_header_level(
-    in_file_name: str, out_file_name: str, mode: str
-) -> None:
+def modify_header_level(input_text: str, mode: str) -> str:
     """
-    Increase or decrease the level of headings by one for text in stdin.
+    Increase or decrease the level of headings by one for the given text.
 
-    :param in_file_name: the name of the input file to read
-    :param out_file_name: the name of the output file to write the
-        modified text to
+    :param input_text: the input text to modify
     :param mode: indicates the increase or decrease of the header level
+    :return: the modified text with header levels adjusted
     """
-    txt = hparser.read_file(in_file_name)
+    lines = input_text.split("\n")
     #
     txt_tmp = []
     if mode == "increase":
@@ -1019,7 +1015,7 @@ def modify_header_level(
         mode_level = -1
     else:
         raise ValueError(f"Unsupported mode='{mode}'")
-    for line in txt:
+    for line in lines:
         # TODO(gp): Use the iterator.
         line = line.rstrip(r"\n")
         is_header_, level, title = is_header(line)
@@ -1034,7 +1030,7 @@ def modify_header_level(
             line = "#" * modified_level + " " + title
         txt_tmp.append(line)
     #
-    hparser.write_file(txt_tmp, out_file_name)
+    return "\n".join(txt_tmp)
 
 
 # #############################################################################

--- a/helpers/test/test_hmarkdown.py
+++ b/helpers/test/test_hmarkdown.py
@@ -104,6 +104,7 @@ def get_header_list5() -> hmarkdo.HeaderList:
 
 
 class Test_header_list_to_vim_cfile1(hunitest.TestCase):
+
     def test_get_header_list1(self) -> None:
         # Prepare inputs.
         markdown_file = "test.py"
@@ -131,6 +132,7 @@ class Test_header_list_to_vim_cfile1(hunitest.TestCase):
 
 
 class Test_header_list_to_markdown1(hunitest.TestCase):
+
     def test_mode_list1(self) -> None:
         # Prepare inputs.
         headers = get_header_list1()
@@ -178,6 +180,7 @@ class Test_header_list_to_markdown1(hunitest.TestCase):
 
 
 class Test_is_markdown_line_separator1(hunitest.TestCase):
+
     def test_valid_separator1(self) -> None:
         # Prepare inputs.
         line = "-----------------------"
@@ -451,7 +454,7 @@ def _get_markdown_slides_example1() -> str:
 def _get_markdown_slides_example2() -> str:
     content = r"""
     # Header1
-    
+
     * Slide1
     Content 1.
     """
@@ -539,6 +542,7 @@ class Test_extract_section_from_markdown1(hunitest.TestCase):
 
 
 class Test_extract_headers_from_markdown1(hunitest.TestCase):
+
     def test_multiple_headers(self) -> None:
         # Prepare inputs.
         content = _get_markdown_example1()
@@ -576,6 +580,7 @@ class Test_extract_headers_from_markdown1(hunitest.TestCase):
 
 
 class Test_extract_slides_from_markdown1(hunitest.TestCase):
+
     def test_multiple_slides(self) -> None:
         # Prepare inputs.
         content = _get_markdown_slides_example1()
@@ -610,6 +615,7 @@ class Test_extract_slides_from_markdown1(hunitest.TestCase):
 
 
 class Test_remove_end_of_line_periods1(hunitest.TestCase):
+
     def test_standard_case(self) -> None:
         txt = "Hello.\nWorld.\nThis is a test."
         act = hmarkdo.remove_end_of_line_periods(txt)
@@ -647,6 +653,7 @@ class Test_remove_end_of_line_periods1(hunitest.TestCase):
 
 
 class Test_process_code_block1(hunitest.TestCase):
+
     def process_code_block(self, txt: str) -> str:
         out: List[str] = []
         in_code_block = False
@@ -752,6 +759,7 @@ def _test_full_navigation_flow(self_: Any, txt: str) -> None:
 
 
 class Test_selected_navigation_to_str1(hunitest.TestCase):
+
     def test1(self) -> None:
         """
         Create navigation bar from Markdown text `_get_markdown_example4()`.
@@ -803,6 +811,7 @@ class Test_selected_navigation_to_str1(hunitest.TestCase):
 
 
 class Test_selected_navigation_to_str2(hunitest.TestCase):
+
     def test1(self) -> None:
         """
         Create navigation bar from Markdown text `_get_markdown_example5()`.
@@ -848,6 +857,7 @@ class Test_selected_navigation_to_str2(hunitest.TestCase):
 
 
 class Test_bold_first_level_bullets1(hunitest.TestCase):
+
     def test1(self) -> None:
         """
         Test basic first-level bullet bolding.
@@ -959,6 +969,7 @@ class Test_bold_first_level_bullets1(hunitest.TestCase):
 
 
 class Test_md_clean_up1(hunitest.TestCase):
+
     def test1(self) -> None:
         # Prepare inputs.
         txt = r"""
@@ -1026,13 +1037,12 @@ class Test_md_clean_up1(hunitest.TestCase):
 
 
 class Test_modify_header_level1(hunitest.TestCase):
+
     def test1(self) -> None:
         """
         Test the inputs to increase headings.
         """
         # Prepare inputs.
-        scratch_dir = self.get_scratch_space()
-        read_file = os.path.join(scratch_dir, "read_file.txt")
         input_text = [
             "# Chapter 1",
             "## Section 1.1",
@@ -1040,10 +1050,8 @@ class Test_modify_header_level1(hunitest.TestCase):
             "#### Sub-subsection 1.1.1.1",
         ]
         input_text = "\n".join(input_text)
-        hio.to_file(read_file, input_text)
         # Call tested function.
-        write_file = os.path.join(scratch_dir, "write_file.txt")
-        hmarkdo.modify_header_level(read_file, write_file, "increase")
+        actual = hmarkdo.modify_header_level(input_text, "increase")
         # Check output.
         expected = [
             "## Chapter 1",
@@ -1052,7 +1060,6 @@ class Test_modify_header_level1(hunitest.TestCase):
             "##### Sub-subsection 1.1.1.1",
         ]
         expected = "\n".join(expected)
-        actual = hio.from_file(write_file)
         self.assertEqual(actual, expected)
 
     def test2(self) -> None:
@@ -1061,18 +1068,13 @@ class Test_modify_header_level1(hunitest.TestCase):
         remain unchanged.
         """
         # Prepare inputs.
-        scratch_dir = self.get_scratch_space()
-        read_file = os.path.join(scratch_dir, "read_file.txt")
         input_text = ["# Chapter 1", "##### Sub-sub-subsection 1.1.1.1.1"]
         input_text = "\n".join(input_text)
-        hio.to_file(read_file, input_text)
         # Call tested function.
-        write_file = os.path.join(scratch_dir, "write_file.txt")
-        hmarkdo.modify_header_level(read_file, write_file, "increase")
+        actual = hmarkdo.modify_header_level(input_text, "increase")
         # Check output.
         expected = ["## Chapter 1", "##### Sub-sub-subsection 1.1.1.1.1"]
         expected = "\n".join(expected)
-        actual = hio.from_file(write_file)
         self.assertEqual(actual, expected)
 
     def test3(self) -> None:
@@ -1081,18 +1083,13 @@ class Test_modify_header_level1(hunitest.TestCase):
         unchanged.
         """
         # Prepare inputs.
-        scratch_dir = self.get_scratch_space()
-        read_file = os.path.join(scratch_dir, "read_file.txt")
         input_text = ["# Chapter 1", "Paragraph 1"]
         input_text = "\n".join(input_text)
-        hio.to_file(read_file, input_text)
         # Call tested function.
-        write_file = os.path.join(scratch_dir, "write_file.txt")
-        hmarkdo.modify_header_level(read_file, write_file, "increase")
+        actual = hmarkdo.modify_header_level(input_text, "increase")
         # Check output.
         expected = ["## Chapter 1", "Paragraph 1"]
         expected = "\n".join(expected)
-        actual = hio.from_file(write_file)
         self.assertEqual(actual, expected)
 
     def test4(self) -> None:
@@ -1100,18 +1097,13 @@ class Test_modify_header_level1(hunitest.TestCase):
         Test inputs of paragraphs which remain unchanged.
         """
         # Prepare inputs.
-        scratch_dir = self.get_scratch_space()
-        read_file = os.path.join(scratch_dir, "read_file.txt")
         input_text = ["Paragraph 1", "Paragraph 2"]
         input_text = "\n".join(input_text)
-        hio.to_file(read_file, input_text)
         # Call tested function.
-        write_file = os.path.join(scratch_dir, "write_file.txt")
-        hmarkdo.modify_header_level(read_file, write_file, "increase")
+        actual = hmarkdo.modify_header_level(input_text, "increase")
         # Check output.
         expected = ["Paragraph 1", "Paragraph 2"]
         expected = "\n".join(expected)
-        actual = hio.from_file(write_file)
         self.assertEqual(actual, expected)
 
     def test5(self) -> None:
@@ -1119,8 +1111,6 @@ class Test_modify_header_level1(hunitest.TestCase):
         Test to increase headings with less than five hashes.
         """
         # Prepare inputs.
-        scratch_dir = self.get_scratch_space()
-        read_file = os.path.join(scratch_dir, "read_file.txt")
         input_text = [
             "# Chapter 1",
             "##### Sub-sub-subsection 1.1.1.1.1",
@@ -1129,10 +1119,8 @@ class Test_modify_header_level1(hunitest.TestCase):
             "# Chapter 3",
         ]
         input_text = "\n".join(input_text)
-        hio.to_file(read_file, input_text)
         # Call tested function.
-        write_file = os.path.join(scratch_dir, "write_file.txt")
-        hmarkdo.modify_header_level(read_file, write_file, "increase")
+        actual = hmarkdo.modify_header_level(input_text, "increase")
         # Check output.
         expected = [
             "## Chapter 1",
@@ -1142,7 +1130,6 @@ class Test_modify_header_level1(hunitest.TestCase):
             "## Chapter 3",
         ]
         expected = "\n".join(expected)
-        actual = hio.from_file(write_file)
         self.assertEqual(actual, expected)
 
     def test6(self) -> None:
@@ -1150,8 +1137,6 @@ class Test_modify_header_level1(hunitest.TestCase):
         Test the inputs to decrease headings.
         """
         # Prepare inputs.
-        scratch_dir = self.get_scratch_space()
-        read_file = os.path.join(scratch_dir, "read_file.txt")
         input_text = [
             "## Section 1.1",
             "### Subsection 1.1.1",
@@ -1159,10 +1144,8 @@ class Test_modify_header_level1(hunitest.TestCase):
             "##### Sub-sub-subsection 1.1.1.1.1",
         ]
         input_text = "\n".join(input_text)
-        hio.to_file(read_file, input_text)
         # Call tested function.
-        write_file = os.path.join(scratch_dir, "write_file.txt")
-        hmarkdo.modify_header_level(read_file, write_file, "decrease")
+        actual = hmarkdo.modify_header_level(input_text, "decrease")
         # Check output.
         expected = [
             "# Section 1.1",
@@ -1171,7 +1154,6 @@ class Test_modify_header_level1(hunitest.TestCase):
             "#### Sub-sub-subsection 1.1.1.1.1",
         ]
         expected = "\n".join(expected)
-        actual = hio.from_file(write_file)
         self.assertEqual(actual, expected)
 
     def test7(self) -> None:
@@ -1179,24 +1161,19 @@ class Test_modify_header_level1(hunitest.TestCase):
         Test inputs to decrease headings with one hash which remains unchanged.
         """
         # Prepare inputs.
-        scratch_dir = self.get_scratch_space()
-        read_file = os.path.join(scratch_dir, "read_file.txt")
         input_text = [
             "# Chapter 1",
             "##### Sub-subsection 1.1.1.1",
         ]
         input_text = "\n".join(input_text)
-        hio.to_file(read_file, input_text)
         # Call tested function.
-        write_file = os.path.join(scratch_dir, "write_file.txt")
-        hmarkdo.modify_header_level(read_file, write_file, "decrease")
+        actual = hmarkdo.modify_header_level(input_text, "decrease")
         # Check output.
         expected = [
             "# Chapter 1",
             "#### Sub-subsection 1.1.1.1",
         ]
         expected = "\n".join(expected)
-        actual = hio.from_file(write_file)
         self.assertEqual(actual, expected)
 
     def test8(self) -> None:
@@ -1204,18 +1181,13 @@ class Test_modify_header_level1(hunitest.TestCase):
         Test inputs of paragraphs which remain unchanged.
         """
         # Prepare inputs.
-        scratch_dir = self.get_scratch_space()
-        read_file = os.path.join(scratch_dir, "read_file.txt")
         input_text = ["Paragraph 1", "Paragraph 2", "Paragraph 3"]
         input_text = "\n".join(input_text)
-        hio.to_file(read_file, input_text)
         # Call tested function.
-        write_file = os.path.join(scratch_dir, "write_file.txt")
-        hmarkdo.modify_header_level(read_file, write_file, "decrease")
+        actual = hmarkdo.modify_header_level(input_text, "decrease")
         # Check output.
         expected = ["Paragraph 1", "Paragraph 2", "Paragraph 3"]
         expected = "\n".join(expected)
-        actual = hio.from_file(write_file)
         self.assertEqual(actual, expected)
 
 
@@ -1225,6 +1197,7 @@ class Test_modify_header_level1(hunitest.TestCase):
 
 
 class Test_format_headers1(hunitest.TestCase):
+
     def test1(self) -> None:
         """
         Test the inputs to check the basic formatting of headings.
@@ -1341,6 +1314,7 @@ class Test_format_headers1(hunitest.TestCase):
 
 
 class Test_remove_code_delimiters1(hunitest.TestCase):
+
     def test1(self) -> None:
         """
         Test a basic example.
@@ -1499,6 +1473,7 @@ class Test_remove_code_delimiters1(hunitest.TestCase):
 
 
 class Test_sanity_check_header_list1(hunitest.TestCase):
+
     def test1(self) -> None:
         """
         Test that the header list with valid level increase is accepted.
@@ -1585,6 +1560,7 @@ def get_header_list6() -> hmarkdo.HeaderList:
 
 
 class Test_convert_header_list_into_guidelines1(hunitest.TestCase):
+
     def test1(self) -> None:
         """
         Test converting a header list into guidelines.
@@ -1614,6 +1590,7 @@ class Test_convert_header_list_into_guidelines1(hunitest.TestCase):
 
 
 class Test_extract_rules1(hunitest.TestCase):
+
     def helper(self, selection_rules: List[str], exp: str) -> None:
         """
         Test extracting rules from a markdown file.
@@ -1679,6 +1656,7 @@ class Test_extract_rules1(hunitest.TestCase):
 
 
 class Test_parse_rules_from_txt1(hunitest.TestCase):
+
     def helper(self, text: str, expected: str) -> None:
         # Prepare inputs.
         text = hprint.dedent(text)
@@ -1790,6 +1768,7 @@ def get_guidelines_txt1() -> str:
 
 
 class Test_end_to_end_rules1(hunitest.TestCase):
+
     def test_get_header_list1(self) -> None:
         """
         Test extracting headers from a markdown file.
@@ -1907,6 +1886,7 @@ class Test_end_to_end_rules1(hunitest.TestCase):
 
 
 class Test_colorize_bold_text1(hunitest.TestCase):
+
     def test1(self) -> None:
         """
         Test basic case with single bold text.
@@ -2069,6 +2049,7 @@ class Test_colorize_bold_text1(hunitest.TestCase):
 
 
 class Test_format_first_level_bullets1(hunitest.TestCase):
+
     def test1(self) -> None:
         """
         Test basic case with single first level bullet.


### PR DESCRIPTION
## Summary

Refactored the `modify_header_level` function to accept string input/output instead of file names, as requested in #903.

## Changes Made

- **Function signature changed**: 
  - From: `modify_header_level(in_file_name: str, out_file_name: str, mode: str) -> None`
  - To: `modify_header_level(input_text: str, mode: str) -> str`

- **Implementation updated**:
  - Uses `input_text.split('\n')` instead of file reading
  - Returns joined string instead of writing to file
  - Maintains all existing functionality and edge case handling

- **Tests updated**: All 8 tests in `Test_modify_header_level1` class refactored to work with string input/output
- **CLI wrapper updated**: `transform_notes.py` now handles file I/O and calls the string-based function

## Test Results

- ✅ All 8 `modify_header_level` tests pass
- ✅ All 99 hmarkdown tests pass  
- ✅ Python syntax validation passed for all modified files
- ✅ Function maintains same behavior and edge case handling

## Files Modified

- `helpers/hmarkdown.py` - Function refactored to use string I/O
- `helpers/test/test_hmarkdown.py` - Tests updated for string-based function
- `dev_scripts_helpers/documentation/transform_notes.py` - CLI wrapper updated

The refactoring improves flexibility while maintaining backward compatibility through the CLI wrapper.

🤖 Generated with [Claude Code](https://claude.ai/code)