### PR TITLE
CmampTask12943_Improve_supports_for_multi_AWS_accounts_2

### DIFF
--- a/helpers/hmoto.py
+++ b/helpers/hmoto.py
@@ -76,7 +76,7 @@ class S3Mock_TestCase(hunitest.TestCase):
         buckets = s3_test_client.list_buckets()["Buckets"]
         self.assertEqual(len(buckets), 1)
         self.assertEqual(buckets[0]["Name"], self.bucket_name)
-        # Patch `get_s3fs`that uses the mocked environment variables.
+        # Patch `get_s3fs` that uses the mocked environment variables.
         self.mock_get_s3fs = umock.patch.object(
             hs3, "get_s3fs", side_effect=self._mock_get_s3fs
         )
@@ -101,7 +101,8 @@ class S3Mock_TestCase(hunitest.TestCase):
         self, aws_profile: Union[str, hs3.S3FileSystem]
     ) -> hs3.S3FileSystem:
         """
-        Mock implementation of get_s3fs that works with moto.
+        Mock implementation of `get_s3fs` to use the mocked environment
+        variables from `moto`.
         """
         from s3fs import S3FileSystem
 

--- a/helpers/hmoto.py
+++ b/helpers/hmoto.py
@@ -22,6 +22,11 @@ import helpers.hs3 as hs3  # noqa: E402 module level import not at top of file  
 import helpers.hunit_test as hunitest  # noqa: E402 module level import not at top of file  # pylint: disable=wrong-import-position
 
 
+# #############################################################################
+# S3Mock_TestCase
+# #############################################################################
+
+
 @pytest.mark.requires_aws
 @pytest.mark.requires_ck_infra
 class S3Mock_TestCase(hunitest.TestCase):
@@ -58,7 +63,6 @@ class S3Mock_TestCase(hunitest.TestCase):
             import helpers.hsecrets as hsecret
 
             self.binance_secret = hsecret.get_secret("binance.preprod.trading.1")
-
         # Start boto3 mock.
         self.mock_s3.start()
         # Start AWS credentials mock. Must be started after moto mock,
@@ -74,12 +78,9 @@ class S3Mock_TestCase(hunitest.TestCase):
         self.assertEqual(buckets[0]["Name"], self.bucket_name)
         # Patch `get_s3fs`that uses the mocked environment variables.
         self.mock_get_s3fs = umock.patch.object(
-            hs3,
-            'get_s3fs',
-            side_effect=self._mock_get_s3fs
+            hs3, "get_s3fs", side_effect=self._mock_get_s3fs
         )
         self.mock_get_s3fs.start()
-        
 
     def tear_down_test(self) -> None:
         # Empty the bucket otherwise deletion will fail.
@@ -90,13 +91,15 @@ class S3Mock_TestCase(hunitest.TestCase):
         # Delete bucket.
         bucket.delete()
         # Stop mocked `get_s3fs`.
-        if hasattr(self, 'mock_get_s3fs'):
+        if hasattr(self, "mock_get_s3fs"):
             self.mock_get_s3fs.stop()
         # Stop moto.
         self.mock_aws_credentials_patch.stop()
         self.mock_s3.stop()
 
-    def _mock_get_s3fs(self, aws_profile: Union[str, hs3.S3FileSystem]) -> hs3.S3FileSystem:
+    def _mock_get_s3fs(
+        self, aws_profile: Union[str, hs3.S3FileSystem]
+    ) -> hs3.S3FileSystem:
         """
         Mock implementation of get_s3fs that works with moto.
         """

--- a/helpers/hmoto.py
+++ b/helpers/hmoto.py
@@ -107,8 +107,5 @@ class S3Mock_TestCase(hunitest.TestCase):
         from s3fs import S3FileSystem
 
         hdbg.dassert_isinstance(aws_profile, (str, S3FileSystem))
-        if isinstance(aws_profile, str):
-            if aws_profile == "__mock__":
-                # Return `S3FileSystem` that uses the mocked environment variables.
-                aws_profile = S3FileSystem(anon=False)
+        aws_profile = S3FileSystem(anon=False)
         return aws_profile

--- a/helpers/hmoto.py
+++ b/helpers/hmoto.py
@@ -5,7 +5,7 @@ import helpers.hmoto as hmoto
 """
 
 import unittest.mock as umock
-from typing import Generator
+from typing import Generator, Union
 
 import pytest  # isort:skip # noqa: E402 # pylint: disable=wrong-import-position
 
@@ -72,16 +72,39 @@ class S3Mock_TestCase(hunitest.TestCase):
         buckets = s3_test_client.list_buckets()["Buckets"]
         self.assertEqual(len(buckets), 1)
         self.assertEqual(buckets[0]["Name"], self.bucket_name)
+        # Patch `get_s3fs`that uses the mocked environment variables.
+        self.mock_get_s3fs = umock.patch.object(
+            hs3,
+            'get_s3fs',
+            side_effect=self._mock_get_s3fs
+        )
+        self.mock_get_s3fs.start()
+        
 
     def tear_down_test(self) -> None:
         # Empty the bucket otherwise deletion will fail.
-        s3 = boto3.resource("s3")
+        s3_client = boto3.resource("s3")
         hdbg.dassert_eq(self.bucket_name, "mock_bucket")
-        bucket = s3.Bucket(self.bucket_name)
+        bucket = s3_client.Bucket(self.bucket_name)
         bucket.objects.all().delete()
         # Delete bucket.
-        s3fs_ = hs3.get_s3fs(self.mock_aws_profile)
-        s3fs_.delete(f"s3://{self.bucket_name}", recursive=True)
+        bucket.delete()
+        # Stop mocked `get_s3fs`.
+        if hasattr(self, 'mock_get_s3fs'):
+            self.mock_get_s3fs.stop()
         # Stop moto.
         self.mock_aws_credentials_patch.stop()
         self.mock_s3.stop()
+
+    def _mock_get_s3fs(self, aws_profile: Union[str, hs3.S3FileSystem]) -> hs3.S3FileSystem:
+        """
+        Mock implementation of get_s3fs that works with moto.
+        """
+        from s3fs import S3FileSystem
+
+        hdbg.dassert_isinstance(aws_profile, (str, S3FileSystem))
+        if isinstance(aws_profile, str):
+            if aws_profile == "__mock__":
+                # Return `S3FileSystem` that uses the mocked environment variables.
+                aws_profile = S3FileSystem(anon=False)
+        return aws_profile

--- a/helpers/hs3.py
+++ b/helpers/hs3.py
@@ -885,6 +885,8 @@ def get_s3fs(aws_profile: AwsProfile) -> S3FileSystem:
                 _LOG.info("Fetching credentials from task IAM role")
                 s3fs_ = S3FileSystem()
             else:
+                # TODO(heanh): Make this manual extraction of credentials
+                # code obsoleted.
                 # From https://stackoverflow.com/questions/62562945
                 # aws_credentials = get_aws_credentials(aws_profile)
                 # _LOG.debug("%s", pprint.pformat(aws_credentials))

--- a/helpers/hs3.py
+++ b/helpers/hs3.py
@@ -879,20 +879,25 @@ def get_s3fs(aws_profile: AwsProfile) -> S3FileSystem:
             # based on passed task role specified in the ECS task-definition,
             # refer to:
             # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
-            if aws_profile == "ck" and hserver.is_inside_ecs_container():
+            if aws_profile in ["ck", "csfy"] and hserver.is_inside_ecs_container():
                 _LOG.info("Fetching credentials from task IAM role")
                 s3fs_ = S3FileSystem()
             else:
                 # From https://stackoverflow.com/questions/62562945
-                aws_credentials = get_aws_credentials(aws_profile)
-                _LOG.debug("%s", pprint.pformat(aws_credentials))
-                s3fs_ = S3FileSystem(
-                    anon=False,
-                    key=aws_credentials["aws_access_key_id"],
-                    secret=aws_credentials["aws_secret_access_key"],
-                    token=aws_credentials["aws_session_token"],
-                    client_kwargs={"region_name": aws_credentials["aws_region"]},
-                )
+                # aws_credentials = get_aws_credentials(aws_profile)
+                # _LOG.debug("%s", pprint.pformat(aws_credentials))
+                # s3fs_ = S3FileSystem(
+                #     anon=False,
+                #     key=aws_credentials["aws_access_key_id"],
+                #     secret=aws_credentials["aws_secret_access_key"],
+                #     token=aws_credentials["aws_session_token"],
+                #     client_kwargs={"region_name": aws_credentials["aws_region"]},
+                # )
+                #
+                # We do not need to extract the credential from the file because
+                # the config (`~/.aws/config`) and credential
+                # (`~/.aws/credentials`) are already set.
+                s3fs_ = S3FileSystem(anon=False, profile=aws_profile)
         elif isinstance(aws_profile, S3FileSystem):
             s3fs_ = aws_profile
         else:

--- a/helpers/hs3.py
+++ b/helpers/hs3.py
@@ -12,7 +12,6 @@ import gzip
 import logging
 import os
 import pathlib
-import pprint
 import re
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -43,6 +42,7 @@ except ModuleNotFoundError:
 
     class S3FileSystem:
         pass
+
 
 # Avoid the following dependency from other `helpers` modules to prevent import cycles.
 # import helpers.hpandas as hpandas
@@ -687,9 +687,7 @@ def generate_aws_files(
     config_file_name = os.path.join(home_dir, ".aws", "config")
     credentials_file_name = os.path.join(home_dir, ".aws", "credentials")
     # Check if the files already exist.
-    if os.path.exists(credentials_file_name) and os.path.exists(
-        config_file_name
-    ):
+    if os.path.exists(credentials_file_name) and os.path.exists(config_file_name):
         _LOG.info(
             "Both files exist: %s and %s; exiting",
             credentials_file_name,
@@ -879,7 +877,11 @@ def get_s3fs(aws_profile: AwsProfile) -> S3FileSystem:
             # based on passed task role specified in the ECS task-definition,
             # refer to:
             # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
-            if aws_profile in ["ck", "csfy"] and hserver.is_inside_ecs_container():
+            if (
+                # TODO(heanh): Centralize the list of supported profiles.
+                aws_profile in ["ck", "csfy"]
+                and hserver.is_inside_ecs_container()
+            ):
                 _LOG.info("Fetching credentials from task IAM role")
                 s3fs_ = S3FileSystem()
             else:


### PR DESCRIPTION
Task https://github.com/causify-ai/cmamp/issues/12943

- Support multiple AWS accounts in the `hs3.py` module