### PR TITLE
CsfyTask7733_get_branch_name_with_functools.lru_cache_shows_the_old_branch_name

### DIFF
--- a/helpers/hgit.py
+++ b/helpers/hgit.py
@@ -11,7 +11,7 @@ import os
 import random
 import re
 import string
-from typing import Any, List, Optional, Tuple, cast
+from typing import List, Optional, Tuple
 
 import helpers.hdbg as hdbg
 import helpers.hprint as hprint


### PR DESCRIPTION
[#7733](https://github.com/causify-ai/csfy/issues/7733)

- remove cache decorator for the [`get_branch_name`](https://github.com/causify-ai/helpers/blob/0aee59f937904a6423b9bafaf08fa6949b6b1078/helpers/hgit.py#L73C5-L73C20)