### PR TITLE
CmampTask7824_Implement_Automatic_Docker_image_build_in_the_helpers_repo_2

### DIFF
--- a/.github/workflows/dev_image_release.yml
+++ b/.github/workflows/dev_image_release.yml
@@ -2,11 +2,6 @@ name: Dev image release
 on:
   # Run manually.
   workflow_dispatch:
-  # Trigger when a PR targeting master is closed (we will check merged + label in the job).
-  pull_request:
-    types: [closed]
-    branches:
-        - master
 # Set up permissions for OIDC authentication.
 permissions:
   # This is required for actions/checkout.


### PR DESCRIPTION
#7824

- Removed triggering the `.github/workflows/dev_image_release.yml` by closing a PR