### PR TITLE
HelpersTask_Fix_Linter_GH_Action_perm

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -5,6 +5,16 @@ on:
     branches:
       - master
   workflow_dispatch:
+# Set up permissions for OIDC authentication.
+permissions:
+  # This is required for requesting the OIDC JWT.
+  id-token: write
+  # This is required for actions/checkout.
+  contents: read
+  # This is required for pulling the Docker image from GHCR.
+  packages: read
+  # This is required for posting the status of the job when triggered manually.
+  statuses: write
 jobs:
   Run_linter:
     uses: ./.github/workflows/common_linter.yml


### PR DESCRIPTION
Pre-commit checks:
All checks passed ✅


It looks like we have to explicitly specify the permission for the caller workflow as well. Previously, it works by just specifying the perms in the reusable workflow.