### PR TITLE
Add actionlint workflow for GitHub Actions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,17 @@
+name: Lint GitHub Actions Workflows
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1.0.6
+        with:
+          scanner: workflow


### PR DESCRIPTION
## Summary
Add GitHub Actions workflow linting using actionlint.

## Changes
- Added  
- Uses rhysd/actionlint@v1.0.6
- Runs on PRs that modify workflow files

## Bounty Claim
- Issue: #673
- Adds linting for workflow files as suggested in the issue

## Testing
- Valid workflow syntax
- Follows project's existing patterns