### PR TITLE
Add lint check for repo reference backticks

### DIFF
--- a/dev_scripts_helpers/documentation/lint_txt.py
+++ b/dev_scripts_helpers/documentation/lint_txt.py
@@ -279,6 +279,50 @@ def _remove_trailing_periods(lines: List[str]) -> List[str]:
     return lines_new
 
 
+def _find_unquoted_repo_references(lines: List[str]) -> List[str]:
+    """
+    Find repo references that should be wrapped in backticks.
+
+    Repo references use the internal `//repo` notation in docs. To keep them
+    rendered consistently, require raw occurrences such as `//cmamp` or
+    `//cmamp/optimizer` to be written as inline code. The formatter extracts
+    protected content before this check, so already backticked references and
+    fenced code blocks are ignored by the normal linting path.
+
+    :param lines: the lines to check after protected-content extraction
+    :return: human-readable violations, including line numbers
+    """
+    _LOG.debug("lines=%s", lines)
+    violations = []
+    pattern = re.compile(r"(?<!\S)//[A-Za-z0-9_][A-Za-z0-9_./-]*")
+    for line_num, line in enumerate(lines, start=1):
+        for match in pattern.finditer(line):
+            reference = match.group(0).rstrip(".,;:)")
+            violations.append(
+                f"line {line_num}: wrap repo reference `{reference}` in "
+                "backticks"
+            )
+    hdbg.dassert_isinstance(violations, list)
+    return violations
+
+
+def _check_repo_references(lines: List[str], in_file_name: str) -> None:
+    """
+    Check that internal `//repo` references are wrapped in backticks.
+
+    :param lines: the lines to check after protected-content extraction
+    :param in_file_name: the file being linted
+    """
+    violations = _find_unquoted_repo_references(lines)
+    for violation in violations:
+        print(f"{in_file_name}:{violation}")
+    hdbg.dassert_eq(
+        len(violations),
+        0,
+        "Found repo references that should be wrapped in backticks",
+    )
+
+
 def _remove_markdown_formatting(lines: List[str]) -> List[str]:
     """
     Remove markdown formatting from text while preserving content.
@@ -585,6 +629,14 @@ def _perform_actions(
             _check_links(in_file_name)
         else:
             _LOG.debug("Skipping link check for non-text file type")
+    # Check internal repo references before restoring protected content, so
+    # already-backticked references and fenced code blocks are ignored.
+    action = "check_repo_references"
+    if _to_execute_action(action, actions):
+        if is_md_file or is_txt_file:
+            _check_repo_references(lines, in_file_name)
+        else:
+            _LOG.debug("Skipping repo reference check for non-text file type")
     # Restore protected content.
     lines = htexprot.restore_protected_content(lines, protected_map)
     # Remove extra indentation from code blocks (after restore).
@@ -632,6 +684,9 @@ _VALID_ACTIONS = [
     "refresh_toc",
     # _check_links(): check if URLs in the file are reachable.
     "check_links",
+    # _check_repo_references(): check that internal repo references such as
+    # `//cmamp` are wrapped in backticks.
+    "check_repo_references",
 ]
 
 

--- a/dev_scripts_helpers/documentation/test/test_lint_txt.py
+++ b/dev_scripts_helpers/documentation/test/test_lint_txt.py
@@ -2354,6 +2354,75 @@ class Test_lint_txt_cmd_line1(hunitest.TestCase):
 # #############################################################################
 
 
+class Test__find_unquoted_repo_references(hunitest.TestCase):
+    """
+    Test the _find_unquoted_repo_references function.
+    """
+
+    def helper(self, txt: str, expected: str) -> None:
+        """
+        Test helper for _find_unquoted_repo_references.
+
+        :param txt: Input text to check
+        :param expected: Expected violations, one per line
+        """
+        # Prepare inputs.
+        lines = txt.split("\n")
+        lines = hprint.dedent(lines, remove_lead_trail_empty_lines_=True)
+        # Run test.
+        actual = dshdlitx._find_unquoted_repo_references(lines)
+        actual = "\n".join(actual)
+        expected = hprint.dedent(expected, remove_lead_trail_empty_lines_=True)
+        self.assert_equal(actual, expected)
+
+    def test1(self) -> None:
+        """
+        Test that raw repo references are reported.
+        """
+        # Prepare inputs.
+        txt = """
+        - The //cmamp repo is a runnable repo
+        - Import from //cmamp/optimizer when needed
+        """
+        # Prepare outputs.
+        expected = """
+        line 1: wrap repo reference `//cmamp` in backticks
+        line 2: wrap repo reference `//cmamp/optimizer` in backticks
+        """
+        # Run test.
+        self.helper(txt, expected)
+
+    def test2(self) -> None:
+        """
+        Test that already protected repo references are ignored.
+        """
+        # Prepare inputs.
+        txt = """
+        - The `//cmamp` repo is a runnable repo
+        - Visit https://example.com//not_a_repo for details
+        - A placeholder __PROTECTED_CONTENT_0__ is ignored
+        """
+        # Prepare outputs.
+        expected = """"""
+        # Run test.
+        self.helper(txt, expected)
+
+    def test3(self) -> None:
+        """
+        Test that trailing punctuation is excluded from the reported reference.
+        """
+        # Prepare inputs.
+        txt = """
+        - See //helpers, then continue
+        """
+        # Prepare outputs.
+        expected = """
+        line 1: wrap repo reference `//helpers` in backticks
+        """
+        # Run test.
+        self.helper(txt, expected)
+
+
 class Test_lint_txt_idempotency(hunitest.TestCase):
     """
     Test that lint_txt.py does not modify already formatted files.


### PR DESCRIPTION
## Summary
- add a `check_repo_references` lint action for raw internal repo references like `//cmamp`
- require those references to be wrapped as inline code/backticks while ignoring already-protected code content and URLs
- add unit coverage for raw references, protected references, and trailing punctuation

Fixes #700

## Verification
- `PYTHONPATH=/home/alce/work/helpers python3 -m py_compile dev_scripts_helpers/documentation/lint_txt.py dev_scripts_helpers/documentation/test/test_lint_txt.py`
- direct Python assertions for `_find_unquoted_repo_references` passed
- attempted `python3 -m pytest dev_scripts_helpers/documentation/test/test_lint_txt.py::Test__find_unquoted_repo_references -q`, but local pytest collection failed before tests with `ModuleNotFoundError: No module named 'helpers.hdbg'` from `conftest.py` despite direct imports succeeding with the same PYTHONPATH
