### PR TITLE
Add Markdown lint for repo names without backticks

### DIFF
--- a/linters/amp_lint_md.py
+++ b/linters/amp_lint_md.py
@@ -12,6 +12,7 @@ import linters.amp_lint_md as lamlimd
 import argparse
 import logging
 import os
+import re
 from typing import List
 
 import helpers.hdbg as hdbg
@@ -29,9 +30,45 @@ def _check_readme_is_capitalized(file_name: str) -> str:
     """
     msg = ""
     basename = os.path.basename(file_name)
-
     if basename.lower() == "readme.md" and basename != "README.md":
         msg = f"{file_name}:1: All README files should be named README.md"
+    return msg
+
+
+def _remove_inline_code(line: str) -> str:
+    """
+    Remove inline code spans from a Markdown line.
+
+    :param line: Markdown line to process
+    :return: line with inline code spans removed
+    """
+    line = re.sub(r"`[^`]*`", "", line)
+    return line
+
+
+def _check_repo_name_has_backticks(
+    file_name: str, line_num: int, line: str
+) -> str:
+    """
+    Issue a warning if a repo name is not enclosed in backticks.
+
+    Repo names in docs use the `//repo` syntax and should be enclosed in
+    Markdown code spans, e.g., `//helpers`.
+
+    :param file_name: name of the file to check
+    :param line_num: line number being checked
+    :param line: Markdown line to check
+    :return: warning message, or an empty string
+    """
+    msg = ""
+    line = _remove_inline_code(line)
+    match = re.search(r"(?<!:)//[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*", line)
+    if match:
+        repo_name = match.group(0)
+        msg = (
+            f"{file_name}:{line_num}: Repo name {repo_name} should be "
+            "enclosed in backticks"
+        )
     return msg
 
 
@@ -74,6 +111,12 @@ class _LintMarkdown(liaction.Action):
         msg = _check_readme_is_capitalized(file_name)
         if msg:
             output.append(msg)
+        # Check that repo names are enclosed in backticks.
+        with open(file_name, encoding="utf-8") as file_obj:
+            for i, line in enumerate(file_obj, start=1):
+                msg = _check_repo_name_has_backticks(file_name, i, line)
+                if msg:
+                    output.append(msg)
         # Remove cruft.
         output = [
             line

--- a/linters/test/test_amp_lint_md.py
+++ b/linters/test/test_amp_lint_md.py
@@ -7,15 +7,83 @@ class Test_check_readme_is_capitalized(hunitest.TestCase):
         """
         Incorrect README name: error.
         """
+        # Prepare inputs.
         file_name = "linter/readme.md"
+        # Prepare outputs.
         expected = f"{file_name}:1: All README files should be named README.md"
+        # Run test.
         msg = lamlimd._check_readme_is_capitalized(file_name)
-        self.assertEqual(expected, msg)
+        # Check outputs.
+        self.assert_equal(expected, msg)
 
     def test2(self) -> None:
         """
         Correct README name: no error.
         """
+        # Prepare inputs.
         file_name = "linter/README.md"
+        # Prepare outputs.
+        expected = ""
+        # Run test.
         msg = lamlimd._check_readme_is_capitalized(file_name)
-        self.assertEqual("", msg)
+        # Check outputs.
+        self.assert_equal(expected, msg)
+
+
+class Test_check_repo_name_has_backticks(hunitest.TestCase):
+    """
+    Test Markdown repo-name backtick checks.
+    """
+
+    def helper(self, line: str, expected: str) -> None:
+        """
+        Test helper for `_check_repo_name_has_backticks()`.
+
+        :param line: Markdown line to check
+        :param expected: expected warning
+        """
+        # Prepare inputs.
+        file_name = "docs/test.md"
+        line_num = 3
+        # Run test.
+        actual = lamlimd._check_repo_name_has_backticks(
+            file_name, line_num, line
+        )
+        # Check outputs.
+        self.assert_equal(expected, actual)
+
+    def test1(self) -> None:
+        """
+        Warn when a repo name is not enclosed in backticks.
+        """
+        # Prepare inputs.
+        line = "Use //helpers as a submodule."
+        # Prepare outputs.
+        expected = (
+            "docs/test.md:3: Repo name //helpers should be enclosed in "
+            "backticks"
+        )
+        # Run test.
+        self.helper(line, expected)
+
+    def test2(self) -> None:
+        """
+        Do not warn when a repo name is enclosed in backticks.
+        """
+        # Prepare inputs.
+        line = "Use `//helpers` as a submodule."
+        # Prepare outputs.
+        expected = ""
+        # Run test.
+        self.helper(line, expected)
+
+    def test3(self) -> None:
+        """
+        Do not warn for URLs.
+        """
+        # Prepare inputs.
+        line = "See https://github.com/causify-ai/helpers."
+        # Prepare outputs.
+        expected = ""
+        # Run test.
+        self.helper(line, expected)


### PR DESCRIPTION
## Summary
- Add a Markdown lint check for repo names using the //repo syntax without backticks.
- Ignore repo names that are already inside inline code spans.
- Avoid matching URLs such as https://github.com/causify-ai/helpers.
- Add unit tests for warning, no-warning, and URL cases.

## Test Plan
- python3 -m py_compile linters/amp_lint_md.py linters/test/test_amp_lint_md.py
- /Users/lgl/.hermes/hermes-agent/venv/bin/python3 - <<'PY'
import importlib.util, sys, pytest
root = '/Users/lgl/bounty-work/helpers'
pkg_dir = root + '/helpers'
spec = importlib.util.spec_from_file_location(
    'helpers', pkg_dir + '/__init__.py', submodule_search_locations=[pkg_dir, root]
)
module = importlib.util.module_from_spec(spec)
sys.modules['helpers'] = module
spec.loader.exec_module(module)
sys.path.insert(0, root)
raise SystemExit(pytest.main(['linters/test/test_amp_lint_md.py','-q']))
PY

Closes #700