### PR TITLE
Fix sync GitHub issue labels test

### DIFF
--- a/dev_scripts_helpers/github/test/test_sync_gh_issue_labels.py
+++ b/dev_scripts_helpers/github/test/test_sync_gh_issue_labels.py
@@ -2,10 +2,7 @@ import logging
 import os
 import unittest.mock as umock
 
-import pytest
-
 import dev_scripts_helpers.github.dockerized_sync_gh_issue_labels as dshgdsgil
-import dev_scripts_helpers.github.sync_gh_issue_labels as dshgsgila
 import helpers.hgit as hgit
 import helpers.hunit_test as hunitest
 
@@ -19,7 +16,6 @@ _LOG = logging.getLogger(__name__)
 
 class Test_sync_gh_issue_labels1(hunitest.TestCase):
 
-    @pytest.mark.skip("Enable after HelpersTask753")
     @umock.patch.dict(os.environ, {"GITHUB_TEST_TOKEN": "fake_token"})
     @umock.patch(
         "dev_scripts_helpers.github.dockerized_sync_gh_issue_labels.github.Github"
@@ -31,7 +27,7 @@ class Test_sync_gh_issue_labels1(hunitest.TestCase):
         directory.
         """
         # Set up mock labels.
-        dshgdsgil.Label("bug", "Something isn't working", "f29513")
+        input_label = dshgdsgil.Label("bug", "Something isn't working", "f29513")
         mock_label = umock.Mock()
         mock_label.name = input_label.name
         mock_label.color = input_label.color
@@ -56,7 +52,7 @@ class Test_sync_gh_issue_labels1(hunitest.TestCase):
             input_args["in_dir_name"], "test_gh_issues_labels.yml"
         )
         git_root_dir = hgit.get_client_root(False)
-        backup_file_name = "tmp.labels.causify-ai.helpers.yaml"
+        backup_file_name = "tmp.labels.test-owner.test-repo.yaml"
         backup_file_path = os.path.join(git_root_dir, backup_file_name)
         # Remove backup file if it exists.
         if os.path.exists(backup_file_path):
@@ -79,8 +75,8 @@ class Test_sync_gh_issue_labels1(hunitest.TestCase):
                 "--dry_run",
             ],
         ):
-            parser = dshgsgila._parse()
-            dshgsgila._main(parser)
+            parser = dshgdsgil._parse()
+            dshgdsgil._main(parser)
         # Check that the backup file exists.
         self.assertTrue(
             os.path.exists(backup_file_path),


### PR DESCRIPTION
## Summary
- re-enable `Test_sync_gh_issue_labels1`
- run the dockerized label sync module directly under the mocked GitHub client
- fix the undefined `input_label` and backup filename expectation so the test exercises the dry-run backup path without calling GitHub

## Validation
- `python3 -m py_compile dev_scripts_helpers/github/dockerized_sync_gh_issue_labels.py dev_scripts_helpers/github/test/test_sync_gh_issue_labels.py`
- manual reproduction of the repaired test body with mocked `github.Github`, which creates the expected backup file

Refs #753
/claim #753
