### PR TITLE
Add actionlint workflow linter

### DIFF
--- a/linters/amp_actionlint.py
+++ b/linters/amp_actionlint.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""
+Run actionlint on GitHub Actions workflow files.
+"""
+
+import logging
+import os
+from typing import List
+
+import helpers.hsystem as hsystem
+import linters.action as liaction
+import linters.utils as liutils
+
+_LOG = logging.getLogger(__name__)
+
+
+class _Actionlint(liaction.Action):
+    def __init__(self) -> None:
+        super().__init__("actionlint")
+
+    def check_if_possible(self) -> bool:
+        return hsystem.check_exec(self._executable)
+
+    def _execute(self, file_name: str, pedantic: int) -> List[str]:
+        is_workflow = (
+            file_name.startswith(os.path.join(".github", "workflows"))
+            and file_name.endswith((".yml", ".yaml"))
+        )
+        if not is_workflow:
+            _LOG.debug("Skipping file_name='%s'", file_name)
+            return []
+        cmd = f"{self._executable} {file_name}"
+        _, output = liutils.tee(cmd, self._executable, abort_on_error=False)
+        return output

--- a/linters/base.py
+++ b/linters/base.py
@@ -33,6 +33,7 @@ import linters.action as liaction
 import linters.add_python_init_files as lapyinfi
 import linters.amp_add_class_frames as laadclfr
 import linters.amp_add_toc_to_notebook as laattono
+import linters.amp_actionlint as laactlin
 import linters.amp_autoflake as lampauto
 import linters.amp_black as lampblac
 import linters.amp_check_file_size as lachfisi
@@ -162,6 +163,11 @@ _MODIFYING_ACTIONS: List[Tuple[str, str, Type[liaction.Action]]] = [
 ]
 
 _NON_MODIFYING_ACTIONS: List[Tuple[str, str, Type[liaction.Action]]] = [
+    (
+        "actionlint",
+        "Checks GitHub Actions workflow files with actionlint",
+        laactlin._Actionlint,  # pylint: disable=protected-access
+    ),
     (
         "check_file_size",
         "Checks if file size is too large",


### PR DESCRIPTION
## Summary
- add a non-modifying linter action that runs `actionlint` on `.github/workflows/*.yml` and `.yaml` files
- wire the new action into the standard linter action list
- skip non-workflow files so regular lint runs are unaffected

## Validation
- `python3 -m py_compile linters/amp_actionlint.py linters/base.py`
- manual smoke: `_Actionlint.check_if_possible()` reports unavailable when `actionlint` is not installed locally and non-workflow files return no output

Refs #673
/claim #673
