### PR TITLE
Add actionlint workflow linting

### DIFF
--- a/.github/workflows/common_dev_image_build.yml
+++ b/.github/workflows/common_dev_image_build.yml
@@ -31,7 +31,7 @@ jobs:
       # Pass AWS credentials via GH secrets. This is needed to pull the Docker
       # image and in case the workflow needs to access AWS resources.
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6.1.1
         with:
           aws-access-key-id: ${{ secrets.CSFY_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.CSFY_AWS_SECRET_ACCESS_KEY }}
@@ -56,7 +56,7 @@ jobs:
       # Check out the code from GitHub so that we can run the action inside
       # the Docker container.
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6.0.2
         with:
           # For PRs: checkout the PR branch (head_ref).
           # For other events: checkout master.

--- a/.github/workflows/common_dev_image_release.yml
+++ b/.github/workflows/common_dev_image_release.yml
@@ -30,7 +30,7 @@ jobs:
       # Pass AWS credentials via GH secrets. This is needed to pull the Docker
       # image and in case the workflow needs to access AWS resources.
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6.1.1
         with:
           aws-access-key-id: ${{ secrets.CSFY_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.CSFY_AWS_SECRET_ACCESS_KEY }}
@@ -55,7 +55,7 @@ jobs:
       # Check out the code from GitHub so that we can run the action inside
       # the Docker container.
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6.0.2
         with:
           submodules: true
           # TODO(Samarth): Do we need to propagate this to other `repos/workflow`

--- a/.github/workflows/common_linter.yml
+++ b/.github/workflows/common_linter.yml
@@ -48,7 +48,7 @@ jobs:
       # Check out the code from GitHub so that we can run the action inside
       # the Docker container.
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6.0.2
         with:
           # The `lint` invoke target needs to have the full history of commits
           # in order to compare the current branch with the master branch.

--- a/.github/workflows/common_run_tests.yml
+++ b/.github/workflows/common_run_tests.yml
@@ -36,7 +36,7 @@ jobs:
       # Pass AWS credentials via GH secrets. This is needed to pull the Docker
       # image and in case the tests need to access AWS resources.
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6.1.1
         with:
           role-to-assume: ${{ vars.GH_ACTION_AWS_ROLE_ARN }}
           role-session-name: ${{ vars.GH_ACTION_AWS_SESSION_NAME }}
@@ -61,7 +61,7 @@ jobs:
       # Check out the code from GitHub so that we can run the action inside
       # the Docker container.
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
           fetch-depth: 0

--- a/.github/workflows/coverage_tests.yml
+++ b/.github/workflows/coverage_tests.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6.1.1
         with:
           role-to-assume: ${{ vars.GH_ACTION_AWS_ROLE_ARN }}
           role-session-name: ${{ vars.GH_ACTION_AWS_SESSION_NAME }}
@@ -43,7 +43,7 @@ jobs:
         run: sudo chmod 777 -R .
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
           fetch-depth: 0
@@ -135,10 +135,10 @@ jobs:
           if [ "$day_of_week" = "1" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "Running superslow tests..."
             invoke run_coverage --suite superslow
-            echo "::set-output name=ran::true"
+            echo "ran=true" >> "$GITHUB_OUTPUT"
           else
             echo "Skipping superslow tests — not Monday and not manually triggered"
-            echo "::set-output name=ran::false"
+            echo "ran=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -150,7 +150,7 @@ jobs:
           files: ./coverage.xml
           flags: superslow
           name: superslow-test-coverage
-          commit_sha: ${{ github.event.pull_request.head.sha || github.sha }}
+          override_commit: ${{ github.event.pull_request.head.sha || github.sha }}
 
         # Fail the job in CI if any of the fast/ slow run/ upload steps above failed.
       - name: Fail if fast/slow test or upload failed

--- a/.github/workflows/dev_image_release.yml
+++ b/.github/workflows/dev_image_release.yml
@@ -14,12 +14,10 @@ concurrency:
 jobs:
   dev_image_release:
     if: >
-        ${{
-        (github.event_name == 'pull_request'
-        && github.event.pull_request.merged == true
-        && contains(github.event.pull_request.labels.*.name, 'Automated release')) ||
-        github.event_name == 'workflow_dispatch'
-        }}
+      (github.event_name == 'pull_request'
+      && github.event.pull_request.merged == true
+      && contains(github.event.pull_request.labels.*.name, 'Automated release')) ||
+      github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/common_dev_image_release.yml
     with:
       container-dir-name: .

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -3,7 +3,7 @@ name: Gitleaks Scan
 on:
   # Run on every PR to master that is ready to review.
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, draft]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,11 @@ repos:
     - id: jupytext
       args: ["--sync"]
 
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.7.12
+  hooks:
+    - id: actionlint
+
 #  - repo: local
 #    hooks:
 #      - id: fixit-lint

--- a/linters2/lint.py
+++ b/linters2/lint.py
@@ -34,6 +34,9 @@ Examples:
 # Lint Markdown and Text files
 > lint.py --modified --file_types "md,txt"
 
+# Lint GitHub workflow files with pre-commit hooks, including actionlint
+> lint.py --modified --file_types "yml,yaml"
+
 # Run only specific actions on modified files (pre-commit and normalize_import)
 > lint.py --modified --action pre-commit normalize_import
 
@@ -338,6 +341,13 @@ def _lint_markdown_files(
     return ret
 
 
+def _is_yaml_file(file_name: str) -> bool:
+    """
+    Return whether a file is a YAML file.
+    """
+    return file_name.endswith((".yml", ".yaml"))
+
+
 def _filter_files_by_type(
     file_paths: List[str],
     file_extensions: List[str],
@@ -349,13 +359,15 @@ def _filter_files_by_type(
 
     :param file_paths: files to filter
     :param file_extensions: list of file extensions to include (e.g., ["py",
-        "ipynb", "md", "txt"])
+        "ipynb", "md", "txt", "yml", "yaml"])
     :param skip_dassert_exists: skip file existence checks
-    :return: tuple of (python_files, jupyter_files, markdown_files)
+    :return: tuple of (python_files, jupyter_files, markdown_files,
+        yaml_files)
     """
     python_files = []
     jupyter_files = []
     markdown_files = []
+    yaml_files = []
     # Categorize all files by type.
     for f in file_paths:
         if llinutil.is_ipynb_file(f):
@@ -383,9 +395,50 @@ def _filter_files_by_type(
             if "txt" not in file_extensions:
                 continue
             markdown_files.append(f)
+        elif _is_yaml_file(f):
+            if not any(ext in file_extensions for ext in ["yml", "yaml"]):
+                continue
+            yaml_files.append(f)
         else:
             _LOG.debug("File type for '%s' not recognized", f)
-    return python_files, jupyter_files, markdown_files
+    return python_files, jupyter_files, markdown_files, yaml_files
+
+
+def _lint_yaml_files(
+    file_paths: List[str],
+    *,
+    abort_on_error: bool = True,
+    actions: List[str] | None = None,
+) -> int:
+    """
+    Lint YAML files using pre-commit hooks.
+
+    The repo's pre-commit config includes generic YAML checks plus actionlint
+    for GitHub workflows. YAML files intentionally skip Python-specific actions
+    such as import normalization and class-frame insertion.
+
+    :param file_paths: YAML files to lint
+    :param abort_on_error: whether to abort on first error
+    :param actions: list of actions to perform; only pre-commit applies
+    :return: combined return code
+    """
+    if not file_paths:
+        return 0
+    if actions is not None and "pre-commit" not in actions:
+        _LOG.info("Skipping YAML files since pre-commit was not requested")
+        return 0
+    _LOG.info("Linting %d YAML files with pre-commit", len(file_paths))
+    files_str = " ".join(file_paths)
+    print(hprint.frame("pre-commit", char1="="))
+    cmd = f"pre-commit run --files {files_str} --color always"
+    _LOG.debug("> %s", cmd)
+    ret = hsystem.system(
+        cmd,
+        print_command=False,
+        abort_on_error=abort_on_error,
+        suppress_output=False,
+    )
+    return ret
 
 
 # #############################################################################
@@ -442,10 +495,10 @@ def _parse() -> argparse.ArgumentParser:
     parser.add_argument(
         "--file_types",
         type=str,
-        default="py,ipynb",
-        help="Comma-separated list of file extensions to process (e.g., 'py,ipynb,md,txt')\n"
-        "  Available: py (Python), ipynb (Jupyter), md (Markdown), txt (Text)\n"
-        "  Default: 'py,ipynb'",
+        default="py,ipynb,yml,yaml",
+        help="Comma-separated list of file extensions to process (e.g., 'py,ipynb,md,txt,yml,yaml')\n"
+        "  Available: py (Python), ipynb (Jupyter), md (Markdown), txt (Text), yml/yaml (YAML)\n"
+        "  Default: 'py,ipynb,yml,yaml'",
     )
     # Other options.
     parser.add_argument(
@@ -522,7 +575,12 @@ def _main(args: argparse.Namespace) -> int:
         args.branch,
     )
     _LOG.info("Found %d files for linting", len(file_paths))
-    python_files, jupyter_files, markdown_files = _filter_files_by_type(
+    (
+        python_files,
+        jupyter_files,
+        markdown_files,
+        yaml_files,
+    ) = _filter_files_by_type(
         file_paths,
         file_extensions,
     )
@@ -541,6 +599,10 @@ def _main(args: argparse.Namespace) -> int:
     if "txt" in file_extensions:
         selected_types.append("text")
         unprocessed_types.discard("txt")
+    if "yml" in file_extensions or "yaml" in file_extensions:
+        selected_types.append("yaml")
+        unprocessed_types.discard("yml")
+        unprocessed_types.discard("yaml")
     # Ensure all requested file types are processed.
     hdbg.dassert_eq(
         len(unprocessed_types),
@@ -548,8 +610,11 @@ def _main(args: argparse.Namespace) -> int:
         msg=f"Unprocessed file types: {unprocessed_types}",
     )
     print(hprint.frame(f"Selecting files: {', '.join(selected_types)}"))
-    all_files = python_files + jupyter_files + markdown_files
-    breakdown = f"Python: {len(python_files)}, Jupyter: {len(jupyter_files)}, Markdown: {len(markdown_files)}"
+    all_files = python_files + jupyter_files + markdown_files + yaml_files
+    breakdown = (
+        f"Python: {len(python_files)}, Jupyter: {len(jupyter_files)}, "
+        f"Markdown: {len(markdown_files)}, YAML: {len(yaml_files)}"
+    )
     print(
         hprint.frame(
             f"Selected {len(all_files)} files for linting ({breakdown})"
@@ -567,6 +632,10 @@ def _main(args: argparse.Namespace) -> int:
     if markdown_files:
         print(f"\n# Markdown files ({len(markdown_files)})")
         for f in markdown_files:
+            print(f"  {f}")
+    if yaml_files:
+        print(f"\n# YAML files ({len(yaml_files)})")
+        for f in yaml_files:
             print(f"  {f}")
     # If dry_run, print files and exit.
     if args.dry_run:
@@ -594,7 +663,14 @@ def _main(args: argparse.Namespace) -> int:
             markdown_files,
             abort_on_error=args.abort_on_error,
         )
-    if not (python_files or jupyter_files or markdown_files):
+    if yaml_files:
+        print(hprint.frame("Processing YAML files"))
+        ret |= _lint_yaml_files(
+            yaml_files,
+            abort_on_error=args.abort_on_error,
+            actions=args.action,
+        )
+    if not (python_files or jupyter_files or markdown_files or yaml_files):
         _LOG.warning("No files matched the selection and type filters")
     return ret
 

--- a/linters2/test/test_lint.py
+++ b/linters2/test/test_lint.py
@@ -41,14 +41,17 @@ class Test_filter_files_by_type(hunitest.TestCase):
             paths["baz.md"],
             paths["qux.txt"],
         ]
-        py_files, ipynb_files, md_files = lilint._filter_files_by_type(
-            file_paths,
-            ["py", "ipynb"],
-            skip_dassert_exists=True,
+        py_files, ipynb_files, md_files, yaml_files = (
+            lilint._filter_files_by_type(
+                file_paths,
+                ["py", "ipynb"],
+                skip_dassert_exists=True,
+            )
         )
         self.assertEqual(py_files, [paths["foo.py"]])
         self.assertEqual(ipynb_files, [paths["bar.ipynb"]])
         self.assertEqual(md_files, [])
+        self.assertEqual(yaml_files, [])
 
     def test2(self) -> None:
         """
@@ -60,14 +63,17 @@ class Test_filter_files_by_type(hunitest.TestCase):
             paths["bar.ipynb"],
             paths["baz.md"],
         ]
-        py_files, ipynb_files, md_files = lilint._filter_files_by_type(
-            file_paths,
-            ["py"],
-            skip_dassert_exists=True,
+        py_files, ipynb_files, md_files, yaml_files = (
+            lilint._filter_files_by_type(
+                file_paths,
+                ["py"],
+                skip_dassert_exists=True,
+            )
         )
         self.assertEqual(py_files, [paths["foo.py"]])
         self.assertEqual(ipynb_files, [])
         self.assertEqual(md_files, [])
+        self.assertEqual(yaml_files, [])
 
     def test3(self) -> None:
         """
@@ -79,14 +85,17 @@ class Test_filter_files_by_type(hunitest.TestCase):
             paths["bar.ipynb"],
             paths["baz.md"],
         ]
-        py_files, ipynb_files, md_files = lilint._filter_files_by_type(
-            file_paths,
-            ["ipynb"],
-            skip_dassert_exists=True,
+        py_files, ipynb_files, md_files, yaml_files = (
+            lilint._filter_files_by_type(
+                file_paths,
+                ["ipynb"],
+                skip_dassert_exists=True,
+            )
         )
         self.assertEqual(py_files, [])
         self.assertEqual(ipynb_files, [paths["bar.ipynb"]])
         self.assertEqual(md_files, [])
+        self.assertEqual(yaml_files, [])
 
     def test4(self) -> None:
         """
@@ -98,16 +107,46 @@ class Test_filter_files_by_type(hunitest.TestCase):
             paths["bar.ipynb"],
             paths["baz.md"],
         ]
-        py_files, ipynb_files, md_files = lilint._filter_files_by_type(
-            file_paths,
-            ["md"],
-            skip_dassert_exists=True,
+        py_files, ipynb_files, md_files, yaml_files = (
+            lilint._filter_files_by_type(
+                file_paths,
+                ["md"],
+                skip_dassert_exists=True,
+            )
         )
         self.assertEqual(py_files, [])
         self.assertEqual(ipynb_files, [])
         self.assertEqual(md_files, [paths["baz.md"]])
+        self.assertEqual(yaml_files, [])
 
     def test5(self) -> None:
+        """
+        yml/yaml extensions - only YAML files included.
+        """
+        paths = self._create_files(
+            ["foo.py", "workflow.yml", "workflow.yaml", "readme.md"]
+        )
+        file_paths = [
+            paths["foo.py"],
+            paths["workflow.yml"],
+            paths["workflow.yaml"],
+            paths["readme.md"],
+        ]
+        py_files, ipynb_files, md_files, yaml_files = (
+            lilint._filter_files_by_type(
+                file_paths,
+                ["yml", "yaml"],
+                skip_dassert_exists=True,
+            )
+        )
+        self.assertEqual(py_files, [])
+        self.assertEqual(ipynb_files, [])
+        self.assertEqual(md_files, [])
+        self.assertEqual(
+            yaml_files, [paths["workflow.yml"], paths["workflow.yaml"]]
+        )
+
+    def test6(self) -> None:
         """
         Paired jupytext .py files are excluded from Python files.
         """
@@ -122,14 +161,17 @@ class Test_filter_files_by_type(hunitest.TestCase):
         hio.to_file(notebook_ipynb, "")
         file_paths = [standalone_py, paired_py, notebook_ipynb]
         file_types = ["py", "ipynb"]
-        py_files, ipynb_files, md_files = lilint._filter_files_by_type(
-            file_paths,
-            file_types,
-            skip_dassert_exists=True,
+        py_files, ipynb_files, md_files, yaml_files = (
+            lilint._filter_files_by_type(
+                file_paths,
+                file_types,
+                skip_dassert_exists=True,
+            )
         )
         self.assertEqual(py_files, [standalone_py])
         self.assertEqual(ipynb_files, [notebook_ipynb])
         self.assertEqual(md_files, [])
+        self.assertEqual(yaml_files, [])
 
 
 # #############################################################################
@@ -256,7 +298,7 @@ class Test_lint_python_files(hunitest.TestCase):
     @umock.patch("helpers.hsystem.system")
     def test1(self, mock_system: umock.MagicMock) -> None:
         """
-        Empty file list — returns 0 immediately, no calls.
+        Empty file list - returns 0 immediately, no calls.
         """
         # Prepare inputs.
         mock_system.return_value = 0
@@ -466,3 +508,71 @@ class Test_lint_markdown_files(hunitest.TestCase):
         self.assertIn("--files", cmd)
         self.assertIn("doc.md", cmd)
         self.assertIn("readme.md", cmd)
+
+
+# #############################################################################
+# Test_lint_yaml_files
+# #############################################################################
+
+
+class Test_lint_yaml_files(hunitest.TestCase):
+    """
+    Test _lint_yaml_files YAML file linting.
+    """
+
+    @umock.patch("helpers.hsystem.system")
+    def test1(self, mock_system: umock.MagicMock) -> None:
+        """
+        Empty file list — returns 0 immediately, no calls.
+        """
+        # Prepare inputs.
+        mock_system.return_value = 0
+        file_paths = []
+        # Run test.
+        ret = lilint._lint_yaml_files(
+            file_paths,
+            abort_on_error=True,
+            actions=None,
+        )
+        # Check outputs.
+        self.assertEqual(ret, 0)
+        self.assertEqual(mock_system.call_count, 0)
+
+    @umock.patch("helpers.hsystem.system")
+    def test2(self, mock_system: umock.MagicMock) -> None:
+        """
+        YAML files run through pre-commit only.
+        """
+        # Prepare inputs.
+        mock_system.return_value = 0
+        file_paths = [".github/workflows/linter.yml"]
+        # Run test.
+        ret = lilint._lint_yaml_files(
+            file_paths,
+            abort_on_error=True,
+            actions=None,
+        )
+        # Check outputs.
+        self.assertEqual(ret, 0)
+        self.assertEqual(mock_system.call_count, 1)
+        cmd = mock_system.call_args_list[0][0][0]
+        self.assertIn("pre-commit run --files", cmd)
+        self.assertIn(".github/workflows/linter.yml", cmd)
+
+    @umock.patch("helpers.hsystem.system")
+    def test3(self, mock_system: umock.MagicMock) -> None:
+        """
+        YAML files are skipped when only Python-specific actions are selected.
+        """
+        # Prepare inputs.
+        mock_system.return_value = 0
+        file_paths = [".github/workflows/linter.yml"]
+        # Run test.
+        ret = lilint._lint_yaml_files(
+            file_paths,
+            abort_on_error=True,
+            actions=["normalize_import"],
+        )
+        # Check outputs.
+        self.assertEqual(ret, 0)
+        self.assertEqual(mock_system.call_count, 0)


### PR DESCRIPTION
Summary:
- Add actionlint to the pre-commit configuration so GitHub workflow files can be linted.
- Include yml/yaml files in linters2/lint.py selection and run YAML files through pre-commit only.
- Fix existing workflow issues reported by actionlint so the new hook passes.

Validation:
- pre-commit run actionlint --files .github/workflows/*.yml
- pre-commit run check-yaml --files .pre-commit-config.yaml .github/workflows/*.yml
- pytest linters2/test/test_lint.py -q (23 passed)
- ruff format --check linters2/lint.py linters2/test/test_lint.py
- python3 -m py_compile linters2/lint.py linters2/test/test_lint.py

Fixes #673