### PR TITLE
Add invoke target for GH issue label sync

### DIFF
--- a/dev_scripts_helpers/github/test/test_sync_gh_issue_labels.py
+++ b/dev_scripts_helpers/github/test/test_sync_gh_issue_labels.py
@@ -8,6 +8,7 @@ import dev_scripts_helpers.github.dockerized_sync_gh_issue_labels as dshgdsgil
 import dev_scripts_helpers.github.sync_gh_issue_labels as dshgsgila
 import helpers.hgit as hgit
 import helpers.hunit_test as hunitest
+import helpers.lib_tasks_gh as hlitagh
 
 _LOG = logging.getLogger(__name__)
 
@@ -85,4 +86,43 @@ class Test_sync_gh_issue_labels1(hunitest.TestCase):
         self.assertTrue(
             os.path.exists(backup_file_path),
             msg="Backup file was not created.",
+        )
+
+
+# #############################################################################
+# Test_sync_gh_issue_labels_invoke_target1
+# #############################################################################
+
+
+class Test_sync_gh_issue_labels_invoke_target1(hunitest.TestCase):
+    def test_parse_repo_names(self) -> None:
+        """
+        Check that the invoke target accepts comma/space-separated repos.
+        """
+        repo_names = hlitagh._parse_gh_repo_names(
+            "helpers,tutorials causify-ai/cmamp"
+        )
+
+        self.assertEqual(repo_names, ["helpers", "tutorials", "cmamp"])
+
+    @umock.patch("helpers.lib_tasks_gh.hsystem.system_to_string")
+    def test_get_all_repos(self, mock_system_to_string: umock.Mock) -> None:
+        """
+        Check that the all-repos mode uses the GitHub CLI output.
+        """
+        mock_system_to_string.return_value = (
+            0,
+            '[{"name": "tutorials"}, {"name": "helpers"}]',
+        )
+
+        repo_names = hlitagh._get_gh_issue_label_repos(
+            "causify-ai",
+            "",
+            True,
+            50,
+        )
+
+        self.assertEqual(repo_names, ["helpers", "tutorials"])
+        mock_system_to_string.assert_called_once_with(
+            "gh repo list causify-ai --json name --limit 50"
         )

--- a/docs/tools/dev_system/all.synchronize_gh_issue_labels.how_to_guide.md
+++ b/docs/tools/dev_system/all.synchronize_gh_issue_labels.how_to_guide.md
@@ -144,16 +144,40 @@ Are you sure you want to synchronize labels? [y/n] y
 
 ### Using Invoke
 
-TODO(\*): Update this section once the invoke target is implemented
-
-- You can run the script using the `invoke` command where `$FILENAME` is the
-  name of the YAML file containing the labels:
+- You can run the script through the `sync_gh_issue_labels` invoke target where
+  `$FILENAME` is the YAML file containing the labels:
 
 ```bash
 > i sync_gh_issue_labels \
-    --input_file $FILENAME \
+    --input-file $FILENAME \
     --owner causify-ai \
     --repo sports_analytics \
-    --token_env_var GITHUB_TOKEN  \
+    --token-env-var GITHUB_TOKEN  \
     --backup
+```
+
+- You can pass multiple repositories as a comma-separated list:
+
+```bash
+> i sync_gh_issue_labels \
+    --input-file $FILENAME \
+    --owner causify-ai \
+    --repo helpers,tutorials \
+    --token-env-var GITHUB_TOKEN \
+    --backup \
+    --dry-run
+```
+
+- To synchronize every repository in an organization, use `--all-repos`.
+  This requires the GitHub CLI to be authenticated and able to list the
+  organization's repositories:
+
+```bash
+> i sync_gh_issue_labels \
+    --input-file $FILENAME \
+    --owner causify-ai \
+    --all-repos \
+    --token-env-var GITHUB_TOKEN \
+    --backup \
+    --dry-run
 ```

--- a/helpers/lib_tasks_gh.py
+++ b/helpers/lib_tasks_gh.py
@@ -16,6 +16,7 @@ from invoke import task
 
 # We want to minimize the dependencies from non-standard Python packages since
 # this code needs to run with minimal dependencies and without Docker.
+import dev_scripts_helpers.github.sync_gh_issue_labels as dshgsgila
 import helpers.hdbg as hdbg
 import helpers.hgit as hgit
 import helpers.hio as hio
@@ -508,6 +509,102 @@ def gh_issue_create(  # type: ignore
     issue_id = int(match.group(1))
     _LOG.info("Created issue #%s", issue_id)
     return issue_id
+
+
+def _parse_gh_repo_names(repo: str) -> List[str]:
+    """
+    Return repo names from a comma/space-separated argument.
+    """
+    repos = [repo_name.strip() for repo_name in re.split(r"[,\s]+", repo)]
+    repos = [repo_name.split("/")[-1] for repo_name in repos if repo_name]
+    return repos
+
+
+def _get_gh_issue_label_repos(
+    owner: str,
+    repo: str,
+    all_repos: bool,
+    repo_limit: int,
+) -> List[str]:
+    """
+    Resolve the target repos for GitHub issue label synchronization.
+    """
+    hdbg.dassert(owner, "GitHub owner/organization must be specified")
+    if all_repos:
+        hdbg.dassert(
+            not repo,
+            "Specify either --repo or --all-repos, but not both",
+        )
+        hdbg.dassert_lte(1, repo_limit)
+        cmd = f"gh repo list {owner} --json name --limit {repo_limit}"
+        _, txt = hsystem.system_to_string(cmd)
+        repos = json.loads(txt)
+        repo_names = sorted(repo["name"] for repo in repos)
+    else:
+        repo_names = _parse_gh_repo_names(repo)
+    hdbg.dassert(repo_names, "No GitHub repositories were selected")
+    return repo_names
+
+
+@task
+def sync_gh_issue_labels(  # type: ignore
+    ctx,
+    input_file,
+    owner="causify-ai",
+    repo="",
+    all_repos=False,
+    repo_limit=1000,
+    token_env_var="GITHUB_TOKEN",
+    prune=False,
+    dry_run=False,
+    backup=True,
+    no_interactive=False,
+    dockerized_force_rebuild=False,
+    dockerized_use_sudo=False,
+):
+    """
+    Synchronize GitHub issue labels for one or more repos.
+
+    ```bash
+    > invoke sync_gh_issue_labels \
+        --input-file dev_scripts_helpers/github/labels/gh_issues_labels.yml \
+        --owner causify-ai \
+        --repo helpers,tutorials \
+        --token-env-var GITHUB_TOKEN \
+        --backup \
+        --dry-run
+
+    > invoke sync_gh_issue_labels \
+        --input-file dev_scripts_helpers/github/labels/gh_issues_labels.yml \
+        --owner causify-ai \
+        --all-repos \
+        --token-env-var GITHUB_TOKEN \
+        --backup \
+        --dry-run
+    ```
+    """
+    _ = ctx
+    hlitauti.report_task(txt=hprint.to_str("input_file owner repo all_repos"))
+    repo_names = _get_gh_issue_label_repos(
+        owner,
+        repo,
+        all_repos,
+        int(repo_limit),
+    )
+    for repo_name in repo_names:
+        _LOG.info("Synchronizing GitHub issue labels for %s/%s", owner, repo_name)
+        dshgsgila._run_dockerized_sync_gh_issue_labels(
+            input_file,
+            owner,
+            repo_name,
+            token_env_var,
+            prune=prune,
+            dry_run=dry_run,
+            backup=backup,
+            no_interactive=no_interactive,
+            force_rebuild=dockerized_force_rebuild,
+            use_sudo=dockerized_use_sudo,
+        )
 
 
 # #############################################################################

--- a/tasks.py
+++ b/tasks.py
@@ -69,6 +69,7 @@ from helpers.lib_tasks import (  # isort: skip # noqa: F401  # pylint: disable=u
     gh_watch,
     gh_workflow_list,
     gh_workflow_run,
+    sync_gh_issue_labels,
     git_add_all_untracked,
     git_backup,
     git_branch_copy,


### PR DESCRIPTION
## Summary
- add `sync_gh_issue_labels` invoke target for one repo, a comma-separated repo list, or all repos in an org
- reuse the existing dockerized label sync implementation instead of duplicating sync logic
- document the invoke workflow and add focused repo-resolution tests

Fixes #439.

## Testing
- `python -m py_compile helpers\lib_tasks_gh.py tasks.py dev_scripts_helpers\github\test\test_sync_gh_issue_labels.py`
- `git diff --check`
- direct helper assertions for repo parsing and `gh repo list` output with local stubs

Note: I could not run the pytest target in this Windows environment because the local Python install does not have `pytest` or `invoke` installed.