### PR TITLE
Update Allure Buildmeister docs and dashboard templates

### DIFF
--- a/dev_scripts_helpers/update_devops_packages/notebooks/Master_buildmeister_dashboard.ipynb
+++ b/dev_scripts_helpers/update_devops_packages/notebooks/Master_buildmeister_dashboard.ipynb
@@ -197,9 +197,9 @@
             "id": "36e93fca",
             "metadata": {},
             "source": [
-                "- fast tests: http://172.30.2.44/allure_reports/cmamp/fast/latest/index.html\n",
-                "- slow tests: http://172.30.2.44/allure_reports/cmamp/slow/latest/index.html\n",
-                "- superslow tests: http://172.30.2.44/allure_reports/cmamp/superslow/latest/index.html"
+                "- fast tests: http://172.30.2.44/allure_reports/csfy/fast/latest/index.html\n",
+                "- slow tests: http://172.30.2.44/allure_reports/csfy/slow/latest/index.html\n",
+                "- superslow tests: http://172.30.2.44/allure_reports/csfy/superslow/latest/index.html"
             ]
         },
         {

--- a/dev_scripts_helpers/update_devops_packages/notebooks/Master_buildmeister_dashboard.py
+++ b/dev_scripts_helpers/update_devops_packages/notebooks/Master_buildmeister_dashboard.py
@@ -90,9 +90,9 @@ hlitagh.render_repo_workflow_status_table(workflow_df, status_color_mapping)
 # # Allure reports
 
 # %% [markdown]
-# - fast tests: http://172.30.2.44/allure_reports/cmamp/fast/latest/index.html
-# - slow tests: http://172.30.2.44/allure_reports/cmamp/slow/latest/index.html
-# - superslow tests: http://172.30.2.44/allure_reports/cmamp/superslow/latest/index.html
+# - fast tests: http://172.30.2.44/allure_reports/csfy/fast/latest/index.html
+# - slow tests: http://172.30.2.44/allure_reports/csfy/slow/latest/index.html
+# - superslow tests: http://172.30.2.44/allure_reports/csfy/superslow/latest/index.html
 
 # %% [markdown]
 # <a name='number-of-open-pull-requests'></a>

--- a/docs/build_system/all.pytest_allure.how_to_guide.md
+++ b/docs/build_system/all.pytest_allure.how_to_guide.md
@@ -14,7 +14,7 @@
 
 ## How to Run the Flow End-To-End Via GH Actions
 
-Considering that we run the tests on the `cmamp` repo with the fast `tests`
+Considering that we run the tests on the `csfy` repo with the fast `tests`
 group
 
 **Important note**: Unlike usual test run, we don't stop the execution on
@@ -22,7 +22,7 @@ failure. For this we use the `continue-on-error: true` in the GitHub action
 step.
 
 Here is the link to the
-[GitHub action file](../.github/workflows/DISABLED.allure.fast_test.yml).
+[GitHub action file](/.github/workflows/allure.fast_test.yml).
 
 ## How to Generate Allure-Pytest Results
 
@@ -41,14 +41,14 @@ To backup the Allure results, copy the `allure_results` directory to a AWS S3
 bucket, e.g.,
 
 ```bash
-aws s3 cp allure_results s3://cryptokaizen-unit-test/allure_test/cmamp/fast/results.20231120_102030 --recursive
+aws s3 cp allure_results s3://cryptokaizen-unit-test/allure_test/csfy/fast/results.20231120_102030 --recursive
 ```
 
 where:
 
 - `allure_results` is the directory where the Allure results are stored
 - `20231120_102030` is the date and time with the mask `%Y%m%d_%H%M%S`
-- `cmamp` is the name of the GitHub repo
+- `csfy` is the name of the GitHub repo
 - `fast` is the name of the tests group
 
 ## How to Generate Allure Html-Report
@@ -94,7 +94,7 @@ TODO(Vlad): Come up with a clean-up strategy for the S3 bucket.
 To copy the history subdirectory from the previous run to the `allure_results`:
 
 ```bash
-aws s3 cp s3://cryptokaizen-html/allure_reports/cmamp/fast/report.20231120_102030/history allure_results/history --recursive
+aws s3 cp s3://cryptokaizen-html/allure_reports/csfy/fast/report.20231120_102030/history allure_results/history --recursive
 ```
 
 ## How to Publish the Allure-Html Report
@@ -103,15 +103,15 @@ To publish the Allure report, copy the `allure_report` directory to a AWS S3
 bucket, e.g.,
 
 ```bash
-aws s3 cp allure_report s3://cryptokaizen-html/allure_reports/cmamp/fast/report.20231120_102030 --recursive
+aws s3 cp allure_report s3://cryptokaizen-html/allure_reports/csfy/fast/report.20231120_102030 --recursive
 ```
 
 where:
 
 - `allure_report` is the directory where the Allure HTML-report will be stored
 - `20231120_102030` is the date and time with the mask `%Y%m%d_%H%M%S`
-- `cmamp` is the name of the GitHub repo
+- `csfy` is the name of the GitHub repo
 - `fast` is the name of the tests group
 
 For e.g., to access the HTML-report open this link on a browser:
-[http://172.30.2.44/allure_reports/cmamp/fast/report.20231120_102030](http://172.30.2.44/allure_reports/cmamp/fast/report.20231120_102030)
+[http://172.30.2.44/allure_reports/csfy/fast/report.20231120_102030/index.html](http://172.30.2.44/allure_reports/csfy/fast/report.20231120_102030/index.html)


### PR DESCRIPTION
Updated the Allure pytest how-to and the Buildmeister dashboard notebook templates to reference the `csfy` repo instead of the legacy `cmamp` paths, so the templates synced into `csfy` no longer point at dead URLs.
Fix the stale link to the disabled workflow in the how-to (`DISABLED.allure.fast_test.yml` → `allure.fast_test.yml`) now that the Allure workflows are back online.
