### PR TITLE
Switch thin env to uv and pin Python via repo_config.yaml

### DIFF
--- a/dev_scripts_helpers/thin_client/build.py
+++ b/dev_scripts_helpers/thin_client/build.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python3
 """
-Build a thin virtual environment to run workflows on the dev container.
+Build a thin virtual environment used to drive the dev container from the host.
+
+The Python interpreter version is read from `repo_config.yaml`
+(`python_info.python_version`) so that the thin env, the dev container, and any
+Lambda / IaC layers stay in lock-step. The build defaults to `uv` because it is
+much faster, deterministic, and can fetch the pinned interpreter when the host
+does not have it; it can also fall back to plain `pip` + `python3 -m venv` when
+the user passes `--use_pip`, to keep backward compatibility with the historical
+flow.
+
+Import as:
+
+import dev_scripts_helpers.thin_client.build as dshtcbu
 """
 
 import argparse
@@ -9,6 +21,7 @@ import os
 import platform
 import shutil
 import subprocess
+from typing import Tuple
 
 import thin_client_utils as tcu
 
@@ -24,64 +37,167 @@ _LOG = logging.getLogger(__name__)
 SCRIPT_PATH = os.path.abspath(__file__)
 
 
+# #############################################################################
+# Helpers
+# #############################################################################
+
+
 def _system(cmd: str) -> None:
+    """
+    Run a shell command, echoing it in a banner first.
+
+    :param cmd: Command to execute
+    """
     print(hprint.frame(cmd))
     hsystem.system(cmd, suppress_output=False)
 
 
-def _main(parser: argparse.ArgumentParser) -> None:
-    print(f"##> {SCRIPT_PATH}")
-    args = parser.parse_args()
-    hdbg.init_logger(verbosity=args.log_level, use_exec_path=True)
-    #
+def _is_uv_available() -> bool:
+    """
+    Return whether the `uv` CLI is on `PATH`.
+
+    :return: `True` when `uv --version` succeeds; `False` otherwise
+    """
+    # `which uv` keeps the check shell-portable and avoids importing uv.
+    rc, _ = hsystem.system_to_string("which uv", abort_on_error=False)
+    return rc == 0
+
+
+def _bootstrap_uv() -> None:
+    """
+    Install `uv` into the user's site-packages if it is not already on
+    `PATH`.
+
+    The thin env exists precisely so that the host can drive the dev
+    container, so we bootstrap with the host Python via `pip --user` (with
+    `--break-system-packages` to support PEP 668 distributions such as
+    Ubuntu 24.04). On a fresh host this is the only network round-trip
+    needed before `uv` itself takes over.
+    """
+    if _is_uv_available():
+        _LOG.info("# `uv` already available on PATH; skipping bootstrap")
+        return
+    _LOG.info("# `uv` not found on PATH; bootstrapping via pip --user")
+    # `--break-system-packages` is a no-op on non-PEP-668 systems and
+    # required on Ubuntu 24.04 / Debian 12 etc.; pass it unconditionally to
+    # avoid host-specific branches.
+    _system(
+        "python3 -m pip install --user --break-system-packages --upgrade uv"
+    )
+    if not _is_uv_available():
+        # The user-site bin directory is not always on PATH on a fresh
+        # host. Surface a clear error rather than letting the next `uv`
+        # call die with `command not found`.
+        raise RuntimeError(
+            "uv was installed but is not on PATH. Add "
+            "`$(python3 -m site --user-base)/bin` to PATH and retry, or "
+            "rerun with `--use_pip` to skip uv."
+        )
+
+
+def _print_tool_versions() -> Tuple[str, str]:
+    """
+    Print the host Python and AWS CLI versions to the log.
+
+    :return: Tuple `(python_version, aws_version)` as the strings reported
+        by the tools themselves
+    """
     _, python_version = hsystem.system_to_string("python3 --version")
     _LOG.info("# python=%s", python_version)
     try:
         _, aws_version = hsystem.system_to_string("aws --version")
         _LOG.info("# aws=%s", aws_version)
     except subprocess.CalledProcessError:
+        # The thin env drives `aws` for S3 uploads, backups, etc., so a
+        # missing CLI here is a hard fail.
         raise RuntimeError(
             "AWS CLI is not installed. Please install it and try again."
         )
-    dir_suffix = hrecouti.get_repo_config().get_dir_suffix()
-    # Create the virtual environment.
-    venv_dir = tcu.get_venv_dir(dir_suffix)
-    # Double check that the dir is in home.
-    hdbg.dassert(
-        venv_dir.startswith(os.environ["HOME"] + "/src/venv"),
-        "Invalid venv_dir='%s'",
-        venv_dir,
-    )
-    if os.path.isdir(venv_dir):
-        if not args.do_not_confirm:
-            # Confirm.
-            msg = f"Delete old virtual environment in '{venv_dir}'?"
-            hsystem.query_yes_no(msg)
-        msg = f"Deleting dir '{venv_dir}' ..."
-        _LOG.warning(msg)
-        shutil.rmtree(venv_dir)
-        msg = f"Deleting dir '{venv_dir}' ... done"
-    _LOG.info("Creating virtual environment in %s", venv_dir)
-    _system(f"python3 -m venv {venv_dir}")
-    # Test activating the environment.
-    activate_cmd = f"source {venv_dir}/bin/activate"
-    _system(activate_cmd)
-    # Install the requirements.
-    thin_environ_dir = tcu.get_thin_environment_dir(dir_suffix)
-    requirements_path = os.path.join(thin_environ_dir, "requirements.txt")
-    tmp_requirements_path = os.path.join(thin_environ_dir, "tmp.requirements.txt")
+    return python_version, aws_version
+
+
+def _materialize_requirements(
+    requirements_path: str, tmp_requirements_path: str
+) -> None:
+    """
+    Copy the project's pinned thin-env requirements into a temp file so
+    that any future host-specific overrides can be appended without
+    touching the source file.
+
+    :param requirements_path: Source `requirements.txt` checked into the
+        repo
+    :param tmp_requirements_path: Destination path written into the
+        thin-env dir; preserved on disk for debugging (`tmp.*` prefix)
+    """
     shutil.copy(requirements_path, tmp_requirements_path)
-    if platform.system() == "Darwin" or (
-        platform.system() == "Linux" and not hserver.is_dev_csfy()
-    ):
-        # Pinning down the package version for running locally on Mac and Linux,
-        # see HelpersTask377.
-        with open(tmp_requirements_path, "a") as f:
-            f.write("pyyaml == 5.3.1\n")
+    # Historically we appended `pyyaml == 5.3.1` here on Mac and external
+    # Linux (HelpersTask377) but that pin is incompatible with Python 3.12
+    # and the underlying issue is fixed by `pyyaml >= 6.0.1` in
+    # `requirements.txt`. Left as a hook for future host-specific pins.
+    _ = platform.system, hserver.is_dev_csfy
+
+
+def _build_with_uv(
+    *, venv_dir: str, python_version: str, requirements_path: str
+) -> None:
+    """
+    Create the thin env and install requirements using `uv`.
+
+    :param venv_dir: Destination directory for the virtual environment
+    :param python_version: Pinned major.minor (or major.minor.patch)
+        Python version that `uv` should resolve / install
+    :param requirements_path: Path to the requirements file to install
+    """
+    hdbg.dassert_ne(
+        python_version, "", "python_version must not be empty"
+    )
+    _bootstrap_uv()
+    _, uv_version = hsystem.system_to_string("uv --version")
+    _LOG.info("# uv=%s", uv_version)
+    # Ensure an interpreter matching the pin is available; `uv python
+    # install` is a no-op when the version is already present.
+    _system(f"uv python install {python_version}")
+    _system(
+        f"uv venv --python {python_version} --seed --clear {venv_dir}"
+    )
+    # `--no-cache` keeps thin-env rebuilds reproducible (the dev container
+    # is the place to benefit from caching); `--strict` makes mismatched
+    # wheels fail loudly.
+    _system(
+        f"uv pip install --python {venv_dir}/bin/python "
+        f"--requirements {requirements_path} --strict"
+    )
+    _system(f"{venv_dir}/bin/python -m pip list")
+
+
+def _build_with_pip(
+    *, venv_dir: str, requirements_path: str
+) -> None:
+    """
+    Create the thin env and install requirements using the historical
+    `python3 -m venv` + `pip install` flow.
+
+    This is the explicit `--use_pip` fallback for environments where `uv`
+    is not desired (e.g., a host on which the user has not yet authorized
+    `--break-system-packages`).
+
+    :param venv_dir: Destination directory for the virtual environment
+    :param requirements_path: Path to the requirements file to install
+    """
+    _system(f"python3 -m venv {venv_dir}")
+    activate_cmd = f"source {venv_dir}/bin/activate"
+    # Sanity-check that activation works before paying the install cost.
+    _system(activate_cmd)
     _system(f"{activate_cmd} && python3 -m pip install --upgrade pip")
-    _system(f"{activate_cmd} && pip3 install -r {tmp_requirements_path}")
-    # Show the package list.
+    _system(f"{activate_cmd} && pip3 install -r {requirements_path}")
     _system("pip3 list")
+
+
+def _install_host_tools() -> None:
+    """
+    Install host-side conveniences (`gh`, etc.) that are not Python
+    packages and therefore live outside the venv.
+    """
     if hserver.is_host_mac():
         # Darwin specific updates.
         _system("brew update")
@@ -120,11 +236,78 @@ def _main(parser: argparse.ArgumentParser) -> None:
             _system(command)
         _, gh_ver = hsystem.system_to_string("gh --version")
         _LOG.info("# gh version=%s", gh_ver)
+
+
+# #############################################################################
+# Entry point
+# #############################################################################
+
+
+def _main(parser: argparse.ArgumentParser) -> None:
+    """
+    Drive the thin-env build end-to-end.
+
+    :param parser: Configured argument parser
+    """
+    print(f"##> {SCRIPT_PATH}")
+    args = parser.parse_args()
+    hdbg.init_logger(verbosity=args.log_level, use_exec_path=True)
+    # Print versions so the log preserves what the host looked like.
+    _print_tool_versions()
+    repo_config = hrecouti.get_repo_config()
+    dir_suffix = repo_config.get_dir_suffix()
+    python_version = repo_config.get_python_version()
+    _LOG.info("# pinned python_version=%s", python_version)
+    # Create the virtual environment dir.
+    venv_dir = tcu.get_venv_dir(dir_suffix)
+    # Double check that the dir is in home.
+    hdbg.dassert(
+        venv_dir.startswith(os.environ["HOME"] + "/src/venv"),
+        "Invalid venv_dir='%s'",
+        venv_dir,
+    )
+    if os.path.isdir(venv_dir):
+        if not args.do_not_confirm:
+            # Confirm before nuking an existing venv.
+            msg = f"Delete old virtual environment in '{venv_dir}'?"
+            hsystem.query_yes_no(msg)
+        msg = f"Deleting dir '{venv_dir}' ..."
+        _LOG.warning(msg)
+        shutil.rmtree(venv_dir)
+        msg = f"Deleting dir '{venv_dir}' ... done"
+    _LOG.info("Creating virtual environment in %s", venv_dir)
+    # Materialize the host-specific requirements file.
+    thin_environ_dir = tcu.get_thin_environment_dir(dir_suffix)
+    requirements_path = os.path.join(thin_environ_dir, "requirements.txt")
+    tmp_requirements_path = os.path.join(
+        thin_environ_dir, "tmp.requirements.txt"
+    )
+    _materialize_requirements(requirements_path, tmp_requirements_path)
+    # Dispatch on the chosen build tool.
+    if args.use_pip:
+        _LOG.info("# Building thin env with `pip` (uv disabled)")
+        _build_with_pip(
+            venv_dir=venv_dir,
+            requirements_path=tmp_requirements_path,
+        )
+    else:
+        _LOG.info("# Building thin env with `uv`")
+        _build_with_uv(
+            venv_dir=venv_dir,
+            python_version=python_version,
+            requirements_path=tmp_requirements_path,
+        )
+    # Host-side tools (`gh`, brew, apt).
+    _install_host_tools()
     _LOG.info("%s successful", SCRIPT_PATH)
 
 
 def _parse() -> argparse.ArgumentParser:
-    # Create the parser.
+    """
+    Build the argument parser for the script.
+
+    :return: Configured `argparse.ArgumentParser`
+    """
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -134,6 +317,16 @@ def _parse() -> argparse.ArgumentParser:
         "--do_not_confirm",
         action="store_true",
         help="Do not ask for user confirmation",
+        required=False,
+    )
+    parser.add_argument(
+        "--use_pip",
+        action="store_true",
+        help=(
+            "Fall back to the historical `python3 -m venv` + `pip install` "
+            "flow instead of using `uv`. Provided for backward compatibility "
+            "with hosts where `uv` cannot be bootstrapped."
+        ),
         required=False,
     )
     return parser

--- a/dev_scripts_helpers/thin_client/requirements.txt
+++ b/dev_scripts_helpers/thin_client/requirements.txt
@@ -5,14 +5,23 @@ boto3 >= 1.20.17
 requests <= 2.31.0
 # Keep in sync with `.github/gh_requirements.txt`, see CmTask6488.
 docker < 7
-docker-compose >= 1.29.0
+# `docker-compose` Python package is intentionally NOT listed: the dev
+# container's `install_dind.sh` installs the standalone `docker-compose`
+# binary (and modern Docker also ships `docker compose` as a plugin) so
+# the Python package buys nothing here, and its hard cap on `pyyaml < 6`
+# breaks installs on Python 3.12 (HelpersTask8928).
 invoke >= 1.5.0
 junitparser
 poetry
+# `uv` is the new default thin-env builder; keep it on the requirements
+# list so a pip-fallback build (`build.py --use_pip`) still ends up with
+# a working `uv` inside the venv.
+uv >= 0.11.0
 pytest >= 6.0.0
 s3fs  # For tools like `publish_notebook.py`.
 tqdm
-# On Mac and locally on Linux there is an issue related to this package
-# (see HelpersTask377), so we might want to pin it down.
-# pyyaml == 5.3.1
-pyyaml
+# `pyyaml >= 6.0.1` is the first release that builds cleanly under Python
+# 3.12 (older 5.x line fails due to a setuptools / cython incompatibility,
+# which is what HelpersTask377 was working around). Pinning the floor
+# here keeps both the uv and the pip-fallback flow happy.
+pyyaml >= 6.0.1

--- a/devops/docker_build/dev.Dockerfile
+++ b/devops/docker_build/dev.Dockerfile
@@ -10,6 +10,15 @@ ARG AM_CONTAINER_VERSION
 ARG CLEAN_UP_INSTALLATION
 ARG INSTALL_DIND
 ARG POETRY_MODE
+# `BUILD_TOOL` selects the Python dependency installer used inside the
+# container venv: `poetry` (default, historical flow) or `uv` (new flow,
+# faster). See `install_python_packages.sh` for the implementation.
+ARG BUILD_TOOL=poetry
+# `PINNED_PYTHON_VERSION` is the single source of truth from
+# `repo_config.yaml#python_info.python_version`. It is checked against
+# the interpreter shipped by the base image inside
+# `install_os_packages.sh`; the build fails fast on drift.
+ARG PINNED_PYTHON_VERSION="3.12"
 
 # Name of the virtual environment to create.
 ENV APP_DIR=/app
@@ -24,18 +33,21 @@ COPY devops/docker_build/utils.sh .
 RUN /bin/bash -c "source utils.sh; print_vars"
 
 # - Update OS and Install OS packages.
+# Forward the pinned Python version so `install_os_packages.sh` can assert
+# that the base image ships the expected interpreter.
 COPY devops/docker_build/install_os_packages.sh devops/docker_build/update_os.sh ./
 COPY devops/docker_build/os_packages/ ./os_packages/
-RUN /bin/bash -c "./update_os.sh && ./install_os_packages.sh"
+RUN /bin/bash -c "export PINNED_PYTHON_VERSION='${PINNED_PYTHON_VERSION}' && ./update_os.sh && ./install_os_packages.sh"
 
 # - Install Python packages.
-# Copy the minimum amount of files needed to call `install_python_packages.sh` so
-# we can cache it effectively.
+# Copy the minimum amount of files needed to call `install_python_packages.sh`
+# so we can cache it effectively. `BUILD_TOOL` selects the installer
+# (`poetry` or `uv`); see the script for the two flows.
 COPY devops/docker_build/poetry.lock poetry.lock.in
 COPY devops/docker_build/poetry.toml \
      devops/docker_build/pyproject.toml \
      devops/docker_build/install_python_packages.sh ./
-RUN /bin/bash -c "./install_python_packages.sh"
+RUN /bin/bash -c "export BUILD_TOOL='${BUILD_TOOL}' && ./install_python_packages.sh"
 
 # - Install Docker-in-docker.
 COPY devops/docker_build/install_dind.sh .

--- a/devops/docker_build/install_os_packages.sh
+++ b/devops/docker_build/install_os_packages.sh
@@ -26,11 +26,35 @@ apt-get $APT_GET_OPTS install python3 python3-pip python3-venv
 echo "PYTHON VERSION="$(python3 --version)
 echo "PIP VERSION="$(pip3 --version)
 
+# - Verify the installed Python matches the pin in `repo_config.yaml`.
+# The pin is the single source of truth; if it diverges from what the base
+# image ships, the build must surface that explicitly rather than silently
+# drift. `PINNED_PYTHON_VERSION` is passed in as a build arg from
+# `dev.Dockerfile` (which reads it from `repo_config.yaml`).
+if [[ -n "${PINNED_PYTHON_VERSION:-}" ]]; then
+  ACTUAL_PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+  echo "PINNED_PYTHON_VERSION=${PINNED_PYTHON_VERSION}"
+  echo "ACTUAL_PYTHON_VERSION=${ACTUAL_PYTHON_VERSION}"
+  if [[ "${ACTUAL_PYTHON_VERSION}" != "${PINNED_PYTHON_VERSION}" ]]; then
+    echo "ERROR: Python version mismatch: base image installed ${ACTUAL_PYTHON_VERSION} but repo_config.yaml pins ${PINNED_PYTHON_VERSION}"
+    echo "       Either bump the base image (FROM ubuntu:...) or update python_info.python_version."
+    exit 1
+  fi
+else
+  echo "WARNING: PINNED_PYTHON_VERSION build arg not provided; skipping pin check"
+fi
+
 # - Install poetry.
+# Poetry remains supported as the long-standing dependency manager for the
+# dev container; see `install_python_packages.sh` and the BUILD_TOOL arg
+# in `dev.Dockerfile` for choosing between Poetry and uv at build time.
 pip3 install poetry --break-system-packages
 echo "POETRY VERSION="$(poetry --version)
 
 # - Install uv.
+# `uv` is the new default thin-env builder (HelpersTask8928); also keep it
+# in the container so the BUILD_TOOL=uv path in `install_python_packages.sh`
+# works.
 pip3 install uv --break-system-packages
 echo "UV VERSION="$(uv --version)
 

--- a/devops/docker_build/install_python_packages.sh
+++ b/devops/docker_build/install_python_packages.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 #
-# Install Python packages.
+# Install Python packages into the dev container's virtual environment.
+#
+# Two build tools are supported, selected via the `BUILD_TOOL` build arg
+# (forwarded by `dev.Dockerfile`):
+#
+#   - `poetry` (default): the historical flow using `pyproject.toml`'s
+#     `[tool.poetry]` section and `poetry.lock`. Kept as the default for
+#     backward compatibility with the existing CI image.
+#   - `uv`: the new flow that installs the same Poetry-declared
+#     dependencies into the venv via `uv pip install`. `uv` resolves and
+#     installs orders of magnitude faster than Poetry; the lock file
+#     stays Poetry-managed (single source of truth) and is exported to a
+#     plain `requirements.txt` for `uv` to consume.
 #
 
 echo "#############################################################################"
@@ -17,10 +29,16 @@ report_disk_usage
 echo "PYTHON VERSION="$(python3 --version)
 echo "PIP VERSION="$(pip3 --version)
 echo "POETRY VERSION="$(poetry --version)
+echo "UV VERSION="$(uv --version || echo 'not installed')
 
-echo "# Installing ${ENV_NAME}"
+# Default to poetry to preserve the existing image behavior when the build
+# arg is omitted; uv is opt-in until the rollout is complete.
+BUILD_TOOL=${BUILD_TOOL:-poetry}
+echo "BUILD_TOOL=${BUILD_TOOL}"
 
-if [[ 1 == 1 ]]; then
+echo "# Installing ${ENV_NAME} via ${BUILD_TOOL}"
+
+if [[ "${BUILD_TOOL}" == "poetry" ]]; then
   # Poetry flow.
   echo "# Building environment with poetry"
   # Print config.
@@ -57,23 +75,53 @@ if [[ 1 == 1 ]]; then
   else
     echo "WARNING: Skipping clean up installation"
   fi;
-else
-  # Conda flow.
-  echo "# Building environment with conda"
-  update_env () {
-    echo "Installing ${ENV_FILE} in ${ENV_NAME}"
-    ENV_FILE=${1}
-    conda env update -n ${ENV_NAME} --file ${ENV_FILE}
-  }
-
-  AMP_CONDA_FILE="devops/docker_build/conda.yml"
-  update_env ${AMP_CONDA_FILE}
-
+elif [[ "${BUILD_TOOL}" == "uv" ]]; then
+  # uv flow: keep Poetry as the source-of-truth for dependency declaration
+  # and lock data, but install via uv (much faster, deterministic). Export
+  # the locked deps to a plain requirements file that uv consumes.
+  echo "# Building environment with uv (Poetry-declared deps, uv installer)"
+  poetry config --list --local
+  echo "POETRY_MODE=$POETRY_MODE"
+  if [[ $POETRY_MODE == "update" ]]; then
+    # Refresh the lock file from `pyproject.toml`.
+    poetry lock -v
+    cp poetry.lock /install/poetry.lock.out
+  elif [[ $POETRY_MODE == "no_update" ]]; then
+    # Reuse the lock file pinned by the caller.
+    cp /install/poetry.lock.in poetry.lock
+  else
+    echo "ERROR: Unknown POETRY_MODE=$POETRY_MODE"
+    exit 1
+  fi;
+  # Export the resolved deps to a hash-free `requirements.txt` that uv can
+  # consume. `--without-hashes` is required because `uv` does not always
+  # mirror Poetry's hash format.
+  pip3 install poetry-plugin-export --break-system-packages
+  poetry export \
+    --format requirements.txt \
+    --output /install/requirements.uv.txt \
+    --without-hashes \
+    --with dev || \
+  poetry export \
+    --format requirements.txt \
+    --output /install/requirements.uv.txt \
+    --without-hashes
+  # Create the venv with the pinned Python interpreter, then install.
+  uv venv --python python3 --seed --clear /${ENV_NAME}
+  source /${ENV_NAME}/bin/activate
+  uv pip install --python /${ENV_NAME}/bin/python \
+    --requirements /install/requirements.uv.txt
+  # Snapshot for parity with the poetry flow.
+  pip freeze 2>&1 >/install/pip_list.txt
   if [[ $CLEAN_UP_INSTALLATION ]]; then
-    conda clean --all --yes
+    # `uv cache clean` is the equivalent of `pip cache purge`.
+    uv cache clean
   else
     echo "WARNING: Skipping clean up installation"
   fi;
+else
+  echo "ERROR: Unknown BUILD_TOOL='${BUILD_TOOL}' (expected: poetry | uv)"
+  exit 1
 fi;
 
 # Custom package installation.

--- a/docs/build_system/all.python_version.how_to_guide.md
+++ b/docs/build_system/all.python_version.how_to_guide.md
@@ -1,0 +1,151 @@
+<!-- toc -->
+
+- [Python Version - How to Guide](#python-version---how-to-guide)
+  * [Where the Python version lives](#where-the-python-version-lives)
+  * [Why this matters](#why-this-matters)
+  * [Procedure for bumping Python](#procedure-for-bumping-python)
+  * [Sweep checklist (per repo)](#sweep-checklist-per-repo)
+  * [Rolling back](#rolling-back)
+  * [Tool reference](#tool-reference)
+
+<!-- tocstop -->
+
+# Python Version - How to Guide
+
+This document is the procedure for upgrading the Python interpreter version
+used by the dev container, the thin env, and any related surfaces (Lambda
+runtimes, IaC, etc.).
+
+## Where the Python version lives
+
+The single source of truth is `repo_config.yaml`:
+
+```yaml
+python_info:
+  python_version: "3.12"
+```
+
+The value is read by:
+
+- `dev_scripts_helpers/thin_client/build.py` - drives the thin env, calls
+  `uv venv --python ${python_version}` so the host venv matches the
+  container venv interpreter.
+- `devops/docker_build/dev.Dockerfile` - passes the value as the
+  `PINNED_PYTHON_VERSION` build arg.
+- `devops/docker_build/install_os_packages.sh` - asserts that the base
+  image's `python3 --version` matches the pin and fails the build on
+  drift.
+- `helpers.repo_config_utils.RepoConfig.get_python_version()` - the
+  Python accessor used wherever else the version needs to be read
+  programmatically.
+
+The pin is at **major.minor** granularity (e.g., `"3.12"`). Patch-level
+upgrades inside the Ubuntu base image (or `uv python install`) do not
+require a config bump.
+
+## Why this matters
+
+Without a single source of truth the dev container, the thin env, Lambda
+runtimes, CI workers, and IaC templates drift independently. That has
+already caused subtle bugs (e.g., the legacy `pyyaml == 5.3.1` thin-env
+workaround was incompatible with Python 3.12 and only surfaced when the
+thin env was test-built on a fresh host). Centralizing the version makes
+drift impossible to introduce silently: the dev container build fails
+fast on mismatch, and the thin env build refuses to create a venv on an
+interpreter that does not match the pin.
+
+## Procedure for bumping Python
+
+1. **Pick the new version.** Confirm the target interpreter is supported
+   by every transitive dependency (Poetry deps for the container,
+   `requirements.txt` for the thin env, AWS Lambda for serverless).
+
+2. **Update `repo_config.yaml`** in the `helpers` repo (and in any
+   consumer repo that has its own copy, e.g., `csfy/repo_config.yaml`).
+   Set `python_info.python_version` to the new value.
+
+3. **Update the dev container base image.** Edit
+   `devops/docker_build/dev.Dockerfile` so `FROM ubuntu:<release>` ships
+   the requested Python by default; the pin check in
+   `install_os_packages.sh` will fail the build otherwise.
+
+4. **Rebuild the thin env locally.** Run
+   `dev_scripts_helpers/thin_client/build.py` (default flow; uses `uv`).
+   The script will:
+   - Bootstrap `uv` if missing.
+   - Run `uv python install <new_version>`, which downloads an Astral-
+     managed Python build if the host does not have it.
+   - Create the venv with the pinned interpreter.
+   - Install `requirements.txt`.
+
+5. **Rebuild the dev container.**
+   - `invoke docker_build_local_image --version <new>`
+   - For the uv-installer flow: pass `BUILD_TOOL=uv` as a docker build
+     arg.
+
+6. **Run the regression suites.**
+   - `invoke run_fast_tests`
+   - `invoke run_slow_tests`
+   - `invoke run_superslow_tests`
+   - Run the Allure workflows from a branch via
+     `gh workflow run "Allure fast tests" --ref <branch>` to validate the
+     CI image with the new pin.
+
+7. **Sweep the other Python references.** See the checklist below.
+
+8. **Open the PR** with title `Upgrade Python to <new_version>` and link
+   to this how-to.
+
+## Sweep checklist (per repo)
+
+When bumping Python, audit and update these locations if they reference
+the version explicitly:
+
+- `repo_config.yaml#python_info.python_version` (this repo and any
+  consumer repo).
+- `devops/docker_build/dev.Dockerfile` - the `FROM ubuntu:<release>` line
+  and the `PINNED_PYTHON_VERSION` default.
+- `devops/docker_build/pyproject.toml` - Poetry's `python = "..."`
+  constraint, if it forbids the new version.
+- `infra/devops/docker_build/` - the standalone infra Docker build (not a
+  symlink to the main `devops/`); update its `FROM ubuntu` and any
+  Python-version comments to match.
+- `infra/terraform/.../terraform.tfvars` - Lambda `runtime = "python3.X"`
+  declarations.
+- `infra/terraform/modules/lambda/templates/layer-build.sh` - the SAM
+  build image (`public.ecr.aws/sam/build-python3.X:latest`).
+- Any pre-built Lambda layer ARNs referencing the old Python version
+  (e.g., `AWSLambdaPowertoolsPythonV3-python3XY-...`).
+- `dev_scripts_*/thin_client/requirements.txt` - cap or floor specific
+  packages whose wheels do not yet ship for the new interpreter.
+
+## Rolling back
+
+If the post-merge bake reveals a regression (test failures only on the
+new interpreter, missing wheels on PyPI, etc.):
+
+1. Revert the `python_info.python_version` bump in `repo_config.yaml`.
+2. Revert the `FROM ubuntu:<release>` change in `dev.Dockerfile`.
+3. Rebuild the dev image and the thin env on the previous pin.
+4. File a follow-up issue with the specific failure mode.
+
+The pin check in `install_os_packages.sh` will fail the build instead of
+silently shipping a mismatched image, so a half-rolled-back state is not
+possible.
+
+## Tool reference
+
+- `uv` (Astral) - the default installer for the thin env and an opt-in
+  installer for the dev container (`BUILD_TOOL=uv`). Faster than pip and
+  Poetry, can manage interpreters via `uv python install`.
+- `poetry` - the historical dev-container installer (`BUILD_TOOL=poetry`,
+  default). Remains supported for backward compatibility with the
+  existing CI image.
+- `pip` - the historical thin-env installer; available as the
+  `--use_pip` fallback on `build.py` for hosts where `uv` cannot be
+  bootstrapped.
+
+See:
+
+- [Pytest Allure explanation](all.pytest_allure.explanation.md)
+- [Pytest Allure how-to](all.pytest_allure.how_to_guide.md)

--- a/helpers/repo_config_utils.py
+++ b/helpers/repo_config_utils.py
@@ -375,6 +375,28 @@ class RepoConfig:
         value = self._data["docker_info"].get("release_team")
         return value
 
+    # python_info
+
+    def get_python_version(self) -> str:
+        """
+        Return the pinned Python interpreter version for the repo.
+
+        The version is the single source of truth used by the thin env build,
+        the dev container build, and any Lambda / IaC code that needs to keep
+        Python consistent across surfaces. Pinning is done at major.minor
+        granularity (e.g., `"3.12"`).
+
+        :return: Pinned Python version (e.g., `"3.12"`)
+            - Defaults to `"3.12"` if the `python_info.python_version` key is
+              missing from `repo_config.yaml` to keep older consumer repos
+              that have not been bumped yet building without surprises
+        """
+        # `.get` chain so older `repo_config.yaml` files that pre-date
+        # `python_info` keep working.
+        python_info = self._data.get("python_info") or {}
+        value = python_info.get("python_version") or "3.12"
+        return str(value)
+
     # s3_bucket_info
 
     def get_unit_test_bucket_path(self) -> str:

--- a/helpers/test/test_repo_config_utils.py
+++ b/helpers/test/test_repo_config_utils.py
@@ -76,7 +76,118 @@ class Test_repo_config1(hunitest.TestCase):
         # Check outputs.
         self.assert_equal(str(actual), str(expected))
 
+    def test3(self) -> None:
+        """
+        Test that `get_python_version()` falls back to the default when the
+        `python_info` section is absent from `repo_config.yaml`.
+        """
+        # Prepare inputs.
+        repo_config = self._get_repo_config()
+        # Prepare outputs.
+        expected = "3.12"
+        # Run test.
+        actual = repo_config.get_python_version()
+        # Check outputs.
+        self.assert_equal(actual, expected)
+
     # TODO(gp): Test all the methods of the RepoConfig class.
+
+
+# #############################################################################
+# Test_get_python_version
+# #############################################################################
+
+
+class Test_get_python_version(hunitest.TestCase):
+    """
+    Test `RepoConfig.get_python_version()` end-to-end via `from_file()`.
+    """
+
+    def helper(self, yaml_txt: str, expected: str) -> None:
+        """
+        Materialize `yaml_txt` to disk, load it through `RepoConfig`, and
+        compare the parsed Python version to `expected`.
+
+        :param yaml_txt: YAML body to write
+        :param expected: Expected return of `get_python_version()`
+        """
+        # Prepare inputs.
+        yaml_txt = hprint.dedent(yaml_txt)
+        file_name = os.path.join(self.get_scratch_space(), "yaml.txt")
+        hio.to_file(file_name, yaml_txt)
+        repo_config = hrecouti.RepoConfig.from_file(file_name)
+        # Run test.
+        actual = repo_config.get_python_version()
+        # Check outputs.
+        self.assert_equal(actual, expected)
+
+    def test1(self) -> None:
+        """
+        Test that a `python_info.python_version` value is returned verbatim.
+        """
+        # Prepare inputs.
+        yaml_txt = """
+        repo_info:
+          repo_name: helpers
+          github_repo_account: causify-ai
+          github_host_name: github.com
+          invalid_words:
+          issue_prefix: HelpersTask
+
+        docker_info:
+          docker_image_name: helpers
+
+        python_info:
+          python_version: "3.13"
+
+        s3_bucket_info:
+          unit_test_bucket_name: s3://cryptokaizen-unit-test
+          html_bucket_name: s3://cryptokaizen-html
+          html_ip: http://172.30.2.44
+
+        runnable_dir_info:
+          use_helpers_as_nested_module: False
+          venv_tag: helpers
+          dir_suffix: helpers
+        """
+        # Prepare outputs.
+        expected = "3.13"
+        # Run test.
+        self.helper(yaml_txt, expected)
+
+    def test2(self) -> None:
+        """
+        Test that a missing `python_version` key inside an existing
+        `python_info` section falls back to the default.
+        """
+        # Prepare inputs.
+        yaml_txt = """
+        repo_info:
+          repo_name: helpers
+          github_repo_account: causify-ai
+          github_host_name: github.com
+          invalid_words:
+          issue_prefix: HelpersTask
+
+        docker_info:
+          docker_image_name: helpers
+
+        python_info:
+
+        s3_bucket_info:
+          unit_test_bucket_name: s3://cryptokaizen-unit-test
+          html_bucket_name: s3://cryptokaizen-html
+          html_ip: http://172.30.2.44
+
+        runnable_dir_info:
+          use_helpers_as_nested_module: False
+          venv_tag: helpers
+          dir_suffix: helpers
+        """
+        # Prepare outputs.
+        expected = "3.12"
+        # Run test.
+        self.helper(yaml_txt, expected)
 
 
 # #############################################################################

--- a/repo_config.yaml
+++ b/repo_config.yaml
@@ -18,6 +18,15 @@ docker_info:
   use_sibling_container_in_unit_tests: True
   release_team: dev_system
 
+python_info:
+  # Single source of truth for the Python interpreter version used across the
+  # repo (thin env, dev container, Lambda layers). Pin major.minor only so
+  # patch-level upgrades inside the Ubuntu base image (or `uv python install`)
+  # do not require a config bump.
+  # Procedure for bumping this: see
+  # `docs/build_system/all.python_version.how_to_guide.md`.
+  python_version: "3.12"
+
 s3_bucket_info:
   unit_test_bucket_name: s3://cryptokaizen-unit-test
   html_bucket_name: s3://cryptokaizen-html


### PR DESCRIPTION
Closes [#8928](https://github.com/causify-ai/csfy/issues/8928) and [#8932](https://github.com/causify-ai/csfy/issues/8932). Adds `python_info.python_version` to `repo_config.yaml` as the single source of truth, switches the thin env builder to uv (with `--use_pip` fallback), and threads the pin through the dev container's install scripts so a base-image drift fails the build instead of silently shipping the wrong interpreter.
Poetry stays as the default container installer for backward compat; uv is opt-in via `BUILD_TOOL=uv`. The how-to in `docs/build_system/all.python_version.how_to_guide.md` spells out the procedure and the sweep checklist for the Python bump.