### PR TITLE
test: enable GitHub label sync wrapper test

### DIFF
--- a/dev_scripts_helpers/github/test/test_sync_gh_issue_labels.py
+++ b/dev_scripts_helpers/github/test/test_sync_gh_issue_labels.py
@@ -2,8 +2,6 @@ import logging
 import os
 import unittest.mock as umock
 
-import pytest
-
 import dev_scripts_helpers.github.dockerized_sync_gh_issue_labels as dshgdsgil
 import dev_scripts_helpers.github.sync_gh_issue_labels as dshgsgila
 import helpers.hgit as hgit
@@ -19,29 +17,35 @@ _LOG = logging.getLogger(__name__)
 
 class Test_sync_gh_issue_labels1(hunitest.TestCase):
 
-    @pytest.mark.skip("Enable after HelpersTask753")
     @umock.patch.dict(os.environ, {"GITHUB_TEST_TOKEN": "fake_token"})
+    @umock.patch(
+        "dev_scripts_helpers.github.sync_gh_issue_labels._run_dockerized_sync_gh_issue_labels"
+    )
     @umock.patch(
         "dev_scripts_helpers.github.dockerized_sync_gh_issue_labels.github.Github"
     )
-    def test1(self, mock_github_cls: umock.Mock) -> None:
+    def test1(
+        self,
+        mock_github_cls: umock.Mock,
+        mock_run_dockerized_sync: umock.Mock,
+    ) -> None:
         """
-        Test that the dockerized executable reads the input file, performs the
-        necessary operations, and writes the backup file in the git root
-        directory.
+        Test that the dockerized wrapper forwards the CLI arguments to the
+        dockerized implementation and that the implementation writes the backup
+        file in the git root directory.
         """
         # Set up mock labels.
-        dshgdsgil.Label("bug", "Something isn't working", "f29513")
+        input_label = dshgdsgil.Label("bug", "Something isn't working", "f29513")
         mock_label = umock.Mock()
         mock_label.name = input_label.name
         mock_label.color = input_label.color
         mock_label.description = input_label.description
-        # Set up mock GitHub repo
+        # Set up mock GitHub repo.
         mock_repo = umock.Mock()
         mock_repo.get_labels.return_value = [mock_label]
         mock_repo.name = "test-repo"
         mock_repo.owner.login = "test-owner"
-        # Set up mock GitHub client
+        # Set up mock GitHub client.
         mock_client = umock.Mock()
         mock_client.get_repo.return_value = mock_repo
         mock_github_cls.return_value = mock_client
@@ -56,12 +60,12 @@ class Test_sync_gh_issue_labels1(hunitest.TestCase):
             input_args["in_dir_name"], "test_gh_issues_labels.yml"
         )
         git_root_dir = hgit.get_client_root(False)
-        backup_file_name = "tmp.labels.causify-ai.helpers.yaml"
+        backup_file_name = "tmp.labels.test-owner.test-repo.yaml"
         backup_file_path = os.path.join(git_root_dir, backup_file_name)
         # Remove backup file if it exists.
         if os.path.exists(backup_file_path):
             os.remove(backup_file_path)
-        # Run.
+        # Run the wrapper.
         with umock.patch(
             "sys.argv",
             [
@@ -81,8 +85,44 @@ class Test_sync_gh_issue_labels1(hunitest.TestCase):
         ):
             parser = dshgsgila._parse()
             dshgsgila._main(parser)
+        # Check that the wrapper forwards all CLI options to the dockerized
+        # implementation.
+        mock_run_dockerized_sync.assert_called_once_with(
+            input_file_path,
+            input_args["owner"],
+            input_args["repo"],
+            input_args["token_env_var"],
+            prune=False,
+            dry_run=True,
+            backup=True,
+            no_interactive=True,
+            force_rebuild=False,
+            use_sudo=False,
+        )
+        # Run the dockerized implementation directly to verify backup behavior.
+        with umock.patch(
+            "sys.argv",
+            [
+                "script",
+                "--input_file",
+                input_file_path,
+                "--owner",
+                input_args["owner"],
+                "--repo",
+                input_args["repo"],
+                "--token_env_var",
+                input_args["token_env_var"],
+                "--backup",
+                "--no_interactive",
+                "--dry_run",
+            ],
+        ):
+            parser = dshgdsgil._parse()
+            dshgdsgil._main(parser)
         # Check that the backup file exists.
         self.assertTrue(
             os.path.exists(backup_file_path),
             msg="Backup file was not created.",
         )
+        # Clean up generated backup file.
+        os.remove(backup_file_path)


### PR DESCRIPTION
## Summary
- Enable `Test_sync_gh_issue_labels1.test1` by fixing the missing `input_label` setup.
- Mock the outer docker wrapper so the test does not require a running Docker daemon.
- Exercise the dockerized implementation directly to verify that `--backup` writes the expected label backup file.

## Verification
- `python -m pytest dev_scripts_helpers/github/test/test_sync_gh_issue_labels.py::Test_sync_gh_issue_labels1::test1 dev_scripts_helpers/github/test/test_dockerized_sync_gh_issue_labels.py::TestLabel1::test_save_label dev_scripts_helpers/github/test/test_dockerized_sync_gh_issue_labels.py::TestLabel1::test_load_label -q -rs` → 3 passed
- `git diff --check` → passed
- Static added-line security scan → `security_findings_count 0`

Closes #753