### PR TITLE
Add RawDescriptionHelpFormatter to all ArgumentParser instances (#1310)

### DIFF
--- a/.claude/control_cc_commit.py
+++ b/.claude/control_cc_commit.py
@@ -124,6 +124,7 @@ def _parse() -> argparse.ArgumentParser:
     :return: Configured argument parser
     """
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
     parser.add_argument(

--- a/dev_scripts_helpers/academic_papers/download_academic_paper.py
+++ b/dev_scripts_helpers/academic_papers/download_academic_paper.py
@@ -410,6 +410,7 @@ def _parse() -> argparse.ArgumentParser:
     """
     _DEFAULT_OUTPUT_DIR = os.path.expanduser(os.getenv("PAPERS_DIR", "."))
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
     parser.add_argument(

--- a/dev_scripts_helpers/dockerize/lib_latex.py
+++ b/dev_scripts_helpers/dockerize/lib_latex.py
@@ -170,7 +170,9 @@ def convert_latex_cmd_to_arguments(cmd: str) -> Dict[str, Any]:
     cmd_list = cmd_list[1:-1]
     _LOG.debug(hprint.to_str("cmd"))
     # Parse arguments.
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument("--output-directory", required=True)
     # Latex uses options like `-XYZ` which confuse `argparse` so we need to
     # replace `-XYZ` with `--XYZ`.

--- a/dev_scripts_helpers/dockerize/lib_pandoc.py
+++ b/dev_scripts_helpers/dockerize/lib_pandoc.py
@@ -248,7 +248,9 @@ def _convert_pandoc_cmd_to_arguments(cmd: str) -> Dict[str, Any]:
     cmd_list = cmd_list[2:]
     _LOG.debug(hprint.to_str("cmd"))
     # Parse arguments.
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument("-o", "--output", required=True)
     parser.add_argument("--data-dir", default=None)
     parser.add_argument("--template", default=None)

--- a/dev_scripts_helpers/documentation/clean_markdown.py
+++ b/dev_scripts_helpers/documentation/clean_markdown.py
@@ -22,6 +22,7 @@ def _parse() -> argparse.ArgumentParser:
     Parse command-line arguments.
     """
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
     parser.add_argument(

--- a/dev_scripts_helpers/documentation/html_to_md.py
+++ b/dev_scripts_helpers/documentation/html_to_md.py
@@ -225,6 +225,7 @@ def _parse() -> argparse.ArgumentParser:
     :return: ArgumentParser instance
     """
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
     parser.add_argument(

--- a/dev_scripts_helpers/documentation/standardize_book_filename.py
+++ b/dev_scripts_helpers/documentation/standardize_book_filename.py
@@ -24,6 +24,7 @@ def _parse() -> argparse.ArgumentParser:
     Parse command-line arguments.
     """
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
     parser.add_argument(

--- a/dev_scripts_helpers/documentation/summarize_chapters.py
+++ b/dev_scripts_helpers/documentation/summarize_chapters.py
@@ -146,7 +146,7 @@ def _parse() -> argparse.ArgumentParser:
     :return: argument parser
     """
     parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     hseinout.add_input_output_args(parser, in_required=False, out_required=False)
     # TODO(gp): Use the factored out parser code.

--- a/dev_scripts_helpers/generate_videos/convert_pdf_to_flip_video.py
+++ b/dev_scripts_helpers/generate_videos/convert_pdf_to_flip_video.py
@@ -203,6 +203,7 @@ def _parse() -> argparse.Namespace:
     :return: parsed arguments
     """
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
     hparser.add_verbosity_arg(parser)

--- a/dev_scripts_helpers/generate_videos/download_synthesia_video.py
+++ b/dev_scripts_helpers/generate_videos/download_synthesia_video.py
@@ -147,7 +147,9 @@ def _parse() -> argparse.Namespace:
 
     :return: parsed arguments
     """
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter, description=__doc__
+    )
     hparser.add_verbosity_arg(parser)
     parser.add_argument(
         "--ids",

--- a/dev_scripts_helpers/generate_videos/extract_png_from_ppt.py
+++ b/dev_scripts_helpers/generate_videos/extract_png_from_ppt.py
@@ -209,6 +209,7 @@ def _parse() -> argparse.Namespace:
     :return: parsed arguments
     """
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
     hparser.add_verbosity_arg(parser)

--- a/dev_scripts_helpers/generate_videos/generate_elevenlabs_voice.py
+++ b/dev_scripts_helpers/generate_videos/generate_elevenlabs_voice.py
@@ -199,7 +199,7 @@ def _parse() -> argparse.Namespace:
     """
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "--in_file",

--- a/dev_scripts_helpers/generate_videos/generate_synthesia_videos.py
+++ b/dev_scripts_helpers/generate_videos/generate_synthesia_videos.py
@@ -152,6 +152,7 @@ def _parse() -> argparse.Namespace:
     :return: parsed arguments
     """
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
     hparser.add_verbosity_arg(parser)

--- a/dev_scripts_helpers/generate_videos/get_synthesia_status.py
+++ b/dev_scripts_helpers/generate_videos/get_synthesia_status.py
@@ -193,6 +193,7 @@ def _parse() -> argparse.Namespace:
     :return: parsed arguments
     """
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
     hparser.add_verbosity_arg(parser)

--- a/dev_scripts_helpers/generate_videos/stop_synthesia_videos.py
+++ b/dev_scripts_helpers/generate_videos/stop_synthesia_videos.py
@@ -137,6 +137,7 @@ def _parse() -> argparse.Namespace:
     :return: parsed arguments
     """
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
     hparser.add_verbosity_arg(parser)

--- a/dev_scripts_helpers/generate_videos_veo3/get_veo3_status.py
+++ b/dev_scripts_helpers/generate_videos_veo3/get_veo3_status.py
@@ -196,6 +196,7 @@ def _parse() -> argparse.Namespace:
     :return: parsed arguments
     """
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
     hparser.add_verbosity_arg(parser)

--- a/dev_scripts_helpers/git/git_productivity_metrics.py
+++ b/dev_scripts_helpers/git/git_productivity_metrics.py
@@ -203,6 +203,7 @@ def _parse() -> argparse.ArgumentParser:
     Parse command line arguments.
     """
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
     parser.add_argument(

--- a/dev_scripts_helpers/github/dockerized_invite_gh_contributors.py
+++ b/dev_scripts_helpers/github/dockerized_invite_gh_contributors.py
@@ -126,7 +126,7 @@ def send_invitations(
 def _parse() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     # Set `--drive_url` and `--csv_file` to be mutually exclusive.
     input_group = parser.add_mutually_exclusive_group(required=True)

--- a/dev_scripts_helpers/github/dockerized_sync_gh_repo_settings.py
+++ b/dev_scripts_helpers/github/dockerized_sync_gh_repo_settings.py
@@ -731,6 +731,7 @@ def _parse() -> argparse.ArgumentParser:
     export_parser = subparsers.add_parser(
         "export",
         help="Save repository and branch protection settings to a YAML file",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     hparser.add_verbosity_arg(export_parser)
     export_parser.add_argument(
@@ -760,6 +761,7 @@ def _parse() -> argparse.ArgumentParser:
     sync_parser = subparsers.add_parser(
         "sync",
         help="Sync repository and branch protection settings from a YAML file",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     hparser.add_verbosity_arg(sync_parser)
     sync_parser.add_argument(

--- a/dev_scripts_helpers/github/gh_migration/bulk_transfer_issues.py
+++ b/dev_scripts_helpers/github/gh_migration/bulk_transfer_issues.py
@@ -292,6 +292,7 @@ def transfer_issue(
 def main() -> None:
     # Parse command-line arguments.
     ap = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description="Bulk transfer GitHub issues (Python, GraphQL)."
     )
     ap.add_argument("--src", default="causify-ai/cmamp")

--- a/dev_scripts_helpers/github/invite_gh_contributors.py
+++ b/dev_scripts_helpers/github/invite_gh_contributors.py
@@ -150,7 +150,7 @@ def _run_dockerized_invite(args: argparse.Namespace) -> None:  # noqa: D401
 def _parse() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     # Set `--drive_url` and `--csv_file` to be mutually exclusive.
     input_group = parser.add_mutually_exclusive_group(required=True)

--- a/dev_scripts_helpers/github/invite_github_collaborator.py
+++ b/dev_scripts_helpers/github/invite_github_collaborator.py
@@ -143,7 +143,9 @@ def _invite_collaborator(
 
 
 def _parse() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument(
         "--github_username",
         type=str,

--- a/dev_scripts_helpers/notebooks/ipynb_format.py
+++ b/dev_scripts_helpers/notebooks/ipynb_format.py
@@ -92,6 +92,7 @@ def ipynb_format(fname, style=None):
 
 def cli():
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description="Format ipython notebook using yapf"
     )
     parser.add_argument("--style", action="store", help="yapf style to use")

--- a/dev_scripts_helpers/notebooks/publish_notebook.py
+++ b/dev_scripts_helpers/notebooks/publish_notebook.py
@@ -213,7 +213,7 @@ def _post_to_webserver(local_src_path: str, remote_dst_path: str) -> None:
 def _parse() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "--file",

--- a/dev_scripts_helpers/system_tools/capture_browser_screenshot.py
+++ b/dev_scripts_helpers/system_tools/capture_browser_screenshot.py
@@ -237,6 +237,7 @@ def _parse() -> argparse.ArgumentParser:
     :return: Configured ArgumentParser instance
     """
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
     parser.add_argument(

--- a/dev_scripts_helpers/system_tools/capture_iterm_command.py
+++ b/dev_scripts_helpers/system_tools/capture_iterm_command.py
@@ -145,6 +145,7 @@ def _parse() -> argparse.ArgumentParser:
     :return: Configured ArgumentParser instance
     """
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
     parser.add_argument(

--- a/helpers/hselect_action.py
+++ b/helpers/hselect_action.py
@@ -21,7 +21,8 @@ _LOG = logging.getLogger(__name__)
 # valid_actions = ["download", "process", "upload", "cleanup"]
 # default_actions = ["download", "process"]
 # # Create parser and add action arguments.
-# parser = argparse.ArgumentParser(...
+# parser = argparse.ArgumentParser(
+formatter_class=argparse.RawDescriptionHelpFormatter,...
 # hparser.add_action_arg(parser, valid_actions, default_actions)
 # args = parser.parse_args()
 # # Select which actions to execute based on CLI arguments.

--- a/helpers/htranslate.py
+++ b/helpers/htranslate.py
@@ -26,7 +26,7 @@ _LOG = logging.getLogger(__name__)
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument(
         "lang",

--- a/helpers/stage_linked_file.py
+++ b/helpers/stage_linked_file.py
@@ -58,6 +58,7 @@ def stage_links(symlinks: List[str]) -> None:
 
 def main():
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description="Stage symbolic links for modification."
     )
     parser.add_argument(

--- a/helpers/test/test_hllm_cli.py
+++ b/helpers/test/test_hllm_cli.py
@@ -1796,7 +1796,9 @@ class Test_add_llm_prompt_arg(hunitest.TestCase):
         Test basic argument addition with is_required=True.
         """
         # Prepare inputs.
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter
+        )
         is_required = True
         default_prompt = ""
         # Run test.
@@ -1820,7 +1822,9 @@ class Test_add_llm_prompt_arg(hunitest.TestCase):
         Test with default_prompt and is_required=False.
         """
         # Prepare inputs.
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter
+        )
         default_prompt = "default test prompt"
         is_required = True
         # Run test.
@@ -1838,7 +1842,9 @@ class Test_add_llm_prompt_arg(hunitest.TestCase):
         Test all arguments are added correctly.
         """
         # Prepare inputs.
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter
+        )
         # Run test.
         hllmcli.add_llm_prompt_arg(parser)
         # Check outputs: parse without errors.
@@ -1853,7 +1859,9 @@ class Test_add_llm_prompt_arg(hunitest.TestCase):
         Test default values for optional flags.
         """
         # Prepare inputs.
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter
+        )
         # Run test.
         hllmcli.add_llm_prompt_arg(
             parser,
@@ -1882,7 +1890,9 @@ class Test_add_llm_args(hunitest.TestCase):
         Test basic LLM arguments with defaults.
         """
         # Prepare inputs.
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter
+        )
         # Run test.
         result_parser = hllmcli.add_llm_args(parser)
         # Check outputs.
@@ -1898,7 +1908,9 @@ class Test_add_llm_args(hunitest.TestCase):
         Test mutually exclusive input options.
         """
         # Prepare inputs.
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter
+        )
         hllmcli.add_llm_args(parser)
         # Parse with input_text instead of input file.
         args = parser.parse_args(["--input_text", "test content"])
@@ -1910,7 +1922,9 @@ class Test_add_llm_args(hunitest.TestCase):
         Test output file option.
         """
         # Prepare inputs.
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter
+        )
         hllmcli.add_llm_args(parser, input_required=False)
         # Parse with output option.
         args = parser.parse_args(["--output", "output.txt"])
@@ -1921,7 +1935,9 @@ class Test_add_llm_args(hunitest.TestCase):
         Test system_prompt options.
         """
         # Prepare inputs.
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter
+        )
         hllmcli.add_llm_args(parser, input_required=False)
         # Parse with system_prompt.
         args = parser.parse_args(["--system_prompt", "test prompt"])
@@ -1933,7 +1949,9 @@ class Test_add_llm_args(hunitest.TestCase):
         Test backend choices.
         """
         # Prepare inputs.
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter
+        )
         hllmcli.add_llm_args(parser, input_required=False)
         # Parse with mock backend.
         args = parser.parse_args(["--backend", "mock"])
@@ -1944,7 +1962,9 @@ class Test_add_llm_args(hunitest.TestCase):
         Test exclude model and backend options.
         """
         # Prepare inputs.
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter
+        )
         hllmcli.add_llm_args(
             parser,
             input_required=False,
@@ -1962,7 +1982,9 @@ class Test_add_llm_args(hunitest.TestCase):
         Test custom model default.
         """
         # Prepare inputs.
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter
+        )
         custom_model = "gpt-5-nano"
         hllmcli.add_llm_args(
             parser,

--- a/linters2/lint.py
+++ b/linters2/lint.py
@@ -625,7 +625,7 @@ def _parse() -> argparse.ArgumentParser:
     """
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     # File selection arguments using hparser helper.
     hseinout.add_file_selection_args(parser)

--- a/linters2/pyright_cfile.py
+++ b/linters2/pyright_cfile.py
@@ -81,6 +81,7 @@ def _parse() -> argparse.ArgumentParser:
     Parse command line arguments.
     """
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
         add_help=True,
     )

--- a/main_pytest.py
+++ b/main_pytest.py
@@ -46,22 +46,28 @@ def _add_common_test_arguments(parser: argparse.ArgumentParser) -> None:
 def _parse() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     subparsers = parser.add_subparsers(dest="command", help="Sub-command help")
     # Add command for running fast tests.
     run_fast_tests_parser = subparsers.add_parser(
-        "run_fast_tests", help="Run fast tests"
+        "run_fast_tests",
+        help="Run fast tests",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     _add_common_test_arguments(run_fast_tests_parser)
     # Add command for running slow tests.
     run_slow_tests_parser = subparsers.add_parser(
-        "run_slow_tests", help="Run slow tests"
+        "run_slow_tests",
+        help="Run slow tests",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     _add_common_test_arguments(run_slow_tests_parser)
     # Add command for running superslow tests.
     run_superslow_tests_parser = subparsers.add_parser(
-        "run_superslow_tests", help="Run superslow tests"
+        "run_superslow_tests",
+        help="Run superslow tests",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     _add_common_test_arguments(run_superslow_tests_parser)
     parser = hparser.add_verbosity_arg(parser)


### PR DESCRIPTION
Adds formatter_class=argparse.RawDescriptionHelpFormatter to all ArgumentParser() and subparsers.add_parser() calls throughout the codebase to ensure multi-line docstrings render with preserved formatting in --help output.

- Updated 33 Python files across helpers, dev_scripts_helpers, linters2, and main_pytest.py
- All existing formatter_class values (RawTextHelpFormatter, ArgumentDefaultsHelpFormatter) are replaced with RawDescriptionHelpFormatter
- Maintains code style compliance (≤81 char line length)
- All files pass syntax validation

Closes #1310