### PR TITLE
HelpersTask1362_Check_pytest_sanity

### DIFF
--- a/dev_scripts_helpers/testing/README.md
+++ b/dev_scripts_helpers/testing/README.md
@@ -10,6 +10,9 @@ This directory has no subdirectories.
 
 ## Description of Files
 
+- [`pytest_check_sanity.py`](pytest_check_sanity.README.md)
+  - Compare independent source definitions with saved pytest evidence and report
+    omitted tests, skips, unexecuted cases, and incomplete captures
 - `pytest_count_files.sh`
   - Count test classes and functions in repository with skip statistics
 - `pytest_failed.py`

--- a/dev_scripts_helpers/testing/pytest_check_sanity.README.md
+++ b/dev_scripts_helpers/testing/pytest_check_sanity.README.md
@@ -1,0 +1,170 @@
+# Pytest Source Sanity Checker
+
+A passing pytest run can still omit tests. This tool compares an independent
+Python source inventory with saved pytest collection and execution evidence.
+It reports omitted definitions, collected cases without outcomes, skips with
+available reasons, failures, and incomplete evidence.
+
+The checker reads files without importing or executing the inspected source.
+Run pytest separately in the environment intended for that project.
+
+## Quick Start
+
+Use the repository's Python 3.11 or newer environment. The optional structured
+input adapter consumes reports from `pytest-json-report`; the checker itself
+does not require that plugin.
+
+```bash
+python -m pytest --json-report --json-report-file=pytest-report.json
+python -m dev_scripts_helpers.testing.pytest_check_sanity \
+  --pytest_input pytest-report.json --code_input . --output sanity.json
+```
+
+Set `--code_input` to the report's pytest root directory. A different root is
+rejected because it would make source-to-node comparisons misleading. Run the
+checker from the helpers checkout with that checkout on Python's import path.
+
+Existing terminal captures are also supported. Capture flat node IDs with
+`--collect-only -q` and individual execution outcomes with `-vv --color=no`:
+
+```bash
+python -m pytest --collect-only -q --color=no > collected.log
+python -m pytest -vv --color=no > executed.log
+python -m dev_scripts_helpers.testing.pytest_check_sanity \
+  --collection_input collected.log --pytest_input executed.log \
+  --code_input . --pytest_cwd . --output sanity.txt --format text
+```
+
+Use the same checkout revision, selection options, environment, and root for
+both captures. `--pytest_cwd` is the original pytest working directory; it
+defaults to the checker's current directory. This matters because verbose
+execution paths are relative to the working directory while flat collection
+IDs are relative to pytest's root.
+
+## Interpretation
+
+For a run with three passing parameter cases, one skip, one deselection, and
+one source test in a directory omitted by pytest, the summary is:
+
+```text
+Summary:
+  deselected: 1
+  not_collected: 1
+  passed: 3
+  skipped: 1
+```
+
+Each case includes its full node ID, source definition when resolved, source
+line, outcome, reason, and whether execution of the call stage was observed.
+Parameter IDs remain separate, including IDs containing spaces and brackets.
+
+| Status | Meaning |
+| --- | --- |
+| `passed`, `failed`, `error` | Reported runtime outcome |
+| `skipped` | Reported skip; reason retained when available |
+| `xfailed`, `xpassed` | Reported expected-failure outcome |
+| `deselected` | Explicitly removed from selection in structured evidence |
+| `unexecuted` | Collected case without an execution outcome |
+| `not_collected` | Source definition absent from a complete collection capture |
+| `excluded` | Explicit source exclusion, such as `__test__ = False` |
+| `collection_error` | Source affected by a reported collection failure |
+| `unknown` | Incomplete collection or conditional source definition |
+
+An unexecuted case is not automatically a skip. A missing log entry never
+supplies a skip reason. Structured setup/call/teardown details are preferred
+when skip explanations or lifecycle distinctions matter.
+
+Reports also include `source_errors`, `source_uncertainties`,
+`collection_errors`, `collection_complete`, and diagnostic warnings. Source
+uncertainties identify imported inheritance, complex class resolution, or
+potential dynamic module definitions. Observed runtime cases whose source
+cannot be resolved have an empty `source` field.
+
+## Configuration
+
+The source scanner reads `python_files`, `python_classes`, and
+`python_functions` from `pytest.ini`, `.pytest.ini`, `pyproject.toml`
+(`[tool.pytest.ini_options]`), `tox.ini`, or `setup.cfg`. Use `--config` to
+select a particular file. Defaults are pytest's conventional naming patterns.
+Native pytest TOML configuration and runtime plugin changes to naming rules
+are not interpreted; provide an INI configuration with the intended patterns.
+
+Pytest's directory exclusions are deliberately not copied: the purpose is to
+find tests hidden by `norecursedirs`, `testpaths`, ignore options, or selection.
+Use repeated `--exclude` directory globs for intentional inventory exclusions:
+
+```bash
+python -m dev_scripts_helpers.testing.pytest_check_sanity \
+  --pytest_input pytest-report.json --code_input . --output sanity.html \
+  --format html --exclude 'vendor' --exclude '**/outcomes'
+```
+
+Git metadata, conventional virtual environments, and Python cache directories
+are excluded by default. Directory symlinks are not followed. File names are
+matched with glob patterns; class and function patterns use pytest's
+prefix-or-glob convention. `unittest.TestCase` uses the `test` method prefix.
+
+## CI Integration
+
+The default policy fails on omitted, unexecuted, unknown, failed, errored, or
+rerun cases. Incomplete collection and source uncertainties also fail the
+default policy, even if every observed case passed or no cases were observed.
+Skips, explicit exclusions, and deselections are visible but do not fail it.
+
+Exit codes are `0` for a satisfied policy, `1` for a policy failure, and `2` for
+source or collection errors. Invalid inputs fail rather than produce a passing
+report. Customize policy with a comma-separated `--fail_on` value. Removing
+`unknown` explicitly opts out of failing incomplete evidence.
+
+Preserve pytest's own result as well as the checker's result:
+
+```bash
+set +e
+python -m pytest --json-report --json-report-file=pytest-report.json
+pytest_status=$?
+python -m dev_scripts_helpers.testing.pytest_check_sanity \
+  --pytest_input pytest-report.json --code_input . --output sanity.json
+sanity_status=$?
+test "$pytest_status" -eq 0 && test "$sanity_status" -eq 0
+```
+
+Upload the report as a CI artifact, including on failure. Review intentional
+skips and exclusions rather than silently deleting omitted tests from inventory.
+
+## Evidence Limits and Troubleshooting
+
+- Use structured reports when possible. Quiet execution dots, verbose
+  collection trees, custom terminal layouts, and interleaved xdist terminal
+  output are not a supported complete inventory. Truncated or unsupported
+  logs are reported as incomplete.
+- `pytest-json-report` under xdist can omit successful collection records.
+  Runtime outcomes remain useful, but do not establish collection completeness.
+  Supply a separate matching serial collection capture when appropriate.
+- A count alone cannot establish which cases were selected. Terminal logs
+  with unnamed deselections remain incomplete. Structured reports can retain
+  the individual deselected IDs.
+- Conditional definitions are inventory candidates, not proof a condition
+  evaluated true. Missing conditional definitions are `unknown`.
+- The AST scanner resolves same-file simple inheritance. Imported bases,
+  multiple inheritance, metaclasses, generated tests, plugin collection hooks,
+  and arbitrary decorators may require project-specific runtime review. The
+  checker does not claim to prove completeness of all executable Python.
+- A separate collection file cannot prove two captures used identical source
+  or options. Unexpected runtime IDs invalidate their combined completeness;
+  use immutable CI artifacts from the same job to avoid stale captures.
+- JSON and text output are deterministic. HTML is a standalone escaped text
+  report, so test identifiers and failure text are never interpreted as markup.
+
+## Tests and Architecture
+
+```bash
+python -m pytest helpers/test/test_hpytest_sanity.py \
+  helpers/test/test_hpytest_sanity_inventory.py \
+  dev_scripts_helpers/testing/test/test_pytest_check_sanity.py
+```
+
+The end-to-end test runs real pytest processes against a temporary project with
+an omitted directory. Unit tests cover parameter IDs, collection failures,
+conditional definitions, inheritance, incomplete evidence, and HTML escaping.
+See the [architecture](pytest_check_sanity.architecture.md) for the component
+boundaries and existing interfaces reused.

--- a/dev_scripts_helpers/testing/pytest_check_sanity.architecture.md
+++ b/dev_scripts_helpers/testing/pytest_check_sanity.architecture.md
@@ -1,0 +1,55 @@
+# Pytest Sanity Architecture
+
+The implementation separates source discovery from runtime observation so
+pytest's own collection exclusions cannot erase the independent inventory.
+
+1. `helpers.hpytest_sanity_inventory` scans matching files with Python's AST
+   parser. It records definitions, source exclusions, conditional definitions,
+   parse errors, and unresolved dynamic constructs. It never imports the code.
+2. `helpers.hpytest_sanity` reads structured `pytest-json-report` objects or
+   saved flat collection and verbose execution logs into `PytestEvidence`.
+   Collection completeness is separate from runtime outcomes.
+3. The same module merges matching captures and reconciles full parameterized
+   node IDs with source definitions. It emits sorted rows and status counts.
+4. `dev_scripts_helpers.testing.pytest_check_sanity` reads naming configuration,
+   selects adapters, renders JSON/text/escaped HTML, and applies the CI policy.
+
+This uses functions and data records rather than an orchestration class with
+one method per phase. Inputs are explicit and testable independently.
+
+## Existing Interfaces
+
+The repository's `pytest_marks.py` and `helpers.hpytest` provide mark
+collection and log analysis. `pytest_count_files.sh` supplies counts. These
+utilities do not independently inventory tests in directories pytest ignores.
+Their APIs remain unchanged.
+
+The structured adapter reuses the public report format of
+[pytest-json-report](https://github.com/numirias/pytest-json-report), including
+collector result nodes, deselection flags, and setup/call/teardown reports.
+This avoids introducing a plugin that alters the test run. The separate
+collection capture uses pytest's existing `--collect-only -q` output.
+
+## Conservative Reconciliation
+
+Full parameter IDs remain the runtime identity; only the callable's parameter
+suffix is removed for source matching. A complete capture needs individual
+collected IDs matching the reported count and no collection errors. Runtime
+outcomes alone cannot prove an absent source test was omitted.
+
+Separate captures must share their root. Merging retains collected cases with
+no outcome and rejects completeness when runtime cases are absent from the
+collection capture. It does not infer skip or deselection from missing output.
+
+The scanner's static limits are explicit. Source errors and uncertainties are
+reported independently of successful observed cases. The default CI policy
+fails uncertainty, and callers can deliberately choose a weaker policy.
+
+## Performance
+
+Directory traversal and parsing are proportional to source size. Reconciliation
+uses dictionaries keyed by node ID; final sorting costs approximately
+`O(n log n)` for `n` reported cases. Evidence and inventory are kept in memory.
+Use inventory exclusions for generated outcomes, vendored trees, and large
+non-project fixtures. Repository collection itself is not performed by this
+command, so importing a large test suite cannot slow the source-only scan.

--- a/dev_scripts_helpers/testing/pytest_check_sanity.py
+++ b/dev_scripts_helpers/testing/pytest_check_sanity.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python
+
+"""
+Compare source tests with saved pytest collection and execution reports.
+
+> pytest_check_sanity.py --pytest_input report.json --code_input . --output
+sanity.json
+
+Use pytest-json-report output or flat collection / verbose execution logs. This
+command reads files only; it does not import or execute the test source.
+"""
+
+import argparse
+import configparser
+import html
+import json
+import logging
+import os
+import shlex
+import sys
+import tomllib
+from typing import Any, Dict, List
+
+import helpers.hdbg as hdbg
+import helpers.hparser as hparser
+import helpers.hpytest_sanity as hpytsani
+import helpers.hpytest_sanity_inventory as hpysainv
+
+_LOG = logging.getLogger(__name__)
+
+
+# #############################################################################
+# Configuration and input adapters
+# #############################################################################
+
+
+def _read_patterns(root: str, config_path: str) -> Dict[str, List[str]]:
+    """Read pytest naming patterns without importing project configuration
+    code.
+    """
+    patterns = {
+        "python_files": ["test_*.py", "*_test.py"],
+        "python_classes": ["Test"],
+        "python_functions": ["test"],
+    }
+    candidates = (
+        [config_path]
+        if config_path
+        else [
+            os.path.join(root, name)
+            for name in (
+                "pytest.ini",
+                ".pytest.ini",
+                "pyproject.toml",
+                "tox.ini",
+                "setup.cfg",
+            )
+        ]
+    )
+    for path in candidates:
+        if not os.path.isfile(path):
+            continue
+        settings: Dict[str, Any] = {}
+        if path.endswith(".toml"):
+            with open(path, "rb") as stream:
+                settings = (
+                    tomllib.load(stream)
+                    .get("tool", {})
+                    .get("pytest", {})
+                    .get("ini_options", {})
+                )
+            if not settings:
+                continue
+        else:
+            config = configparser.ConfigParser(interpolation=None)
+            config.read(path, encoding="utf-8")
+            section = "tool:pytest" if path.endswith("setup.cfg") else "pytest"
+            if config.has_section(section):
+                settings = dict(config[section])
+            elif not path.endswith("pytest.ini"):
+                continue
+        for name in patterns:
+            if name in settings:
+                value = settings[name]
+                patterns[name] = (
+                    shlex.split(value) if isinstance(value, str) else list(value)
+                )
+        break
+    return patterns
+
+
+def _read_evidence(
+    path: str, root: str, invocation_dir: str
+) -> hpytsani.PytestEvidence:
+    """Select a structured or terminal adapter for one saved report."""
+    with open(path, encoding="utf-8-sig") as stream:
+        text = stream.read()
+    if text.lstrip().startswith("{"):
+        evidence = hpytsani.parse_json_report(json.loads(text))
+        hdbg.dassert_eq(
+            os.path.abspath(evidence.root),
+            root,
+            "Use the report's pytest root as --code_input",
+        )
+    else:
+        evidence = hpytsani.parse_terminal_report(
+            text, root, invocation_dir=invocation_dir
+        )
+    return evidence
+
+
+def _render_report(report: Dict[str, Any], output_format: str) -> str:
+    """Render deterministic machine-readable or human-readable output."""
+    if output_format == "json":
+        return json.dumps(report, indent=2, sort_keys=True) + "\n"
+    lines = ["Pytest source sanity", "", "Summary:"]
+    lines.extend(
+        f"  {name}: {count}" for name, count in report["summary"].items()
+    )
+    lines.extend(["", "Tests:"])
+    for item in report["tests"]:
+        lines.append(f"  {item['status']}: {item['nodeid']}")
+        if item["reason"]:
+            lines.append(f"    {item['reason']}")
+    for category in (
+        "source_errors",
+        "collection_errors",
+        "source_uncertainties",
+    ):
+        for path, reason in report.get(category, {}).items():
+            lines.append(f"{category}: {path}: {reason}")
+    lines.extend(f"Warning: {warning}" for warning in report["warnings"])
+    text = "\n".join(lines) + "\n"
+    if output_format == "html":
+        # Source identifiers and error text are data, never HTML markup.
+        return (
+            '<!doctype html><html lang="en"><meta charset="utf-8">'
+            "<title>Pytest source sanity</title><body><pre>"
+            + html.escape(text)
+            + "</pre></body></html>\n"
+        )
+    return text
+
+
+# #############################################################################
+# CLI
+# #############################################################################
+
+
+def _parse() -> argparse.ArgumentParser:
+    """Build the public command-line interface."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pytest_input", required=True, help="Execution or collection report"
+    )
+    parser.add_argument(
+        "--collection_input", default="", help="Matching full collection report"
+    )
+    parser.add_argument(
+        "--code_input", required=True, help="Source / node-ID root directory"
+    )
+    parser.add_argument(
+        "--pytest_cwd",
+        default=os.getcwd(),
+        help="Working directory of the saved pytest run",
+    )
+    parser.add_argument("--output", required=True, help="Output report path")
+    parser.add_argument(
+        "--format", choices=("json", "text", "html"), default="json"
+    )
+    parser.add_argument(
+        "--config", default="", help="Explicit pytest naming configuration"
+    )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        help="Additional inventory directory glob",
+    )
+    parser.add_argument(
+        "--fail_on",
+        default="not_collected,unexecuted,unknown,failed,error,collection_error,rerun",
+    )
+    hparser.add_verbosity_arg(parser)
+    return parser
+
+
+def _main(parser: argparse.ArgumentParser) -> int:
+    """Reconcile saved evidence and return a CI-friendly result code."""
+    args = parser.parse_args()
+    hdbg.init_logger(verbosity=args.log_level, use_exec_path=False)
+    root = os.path.abspath(args.code_input)
+    patterns = _read_patterns(root, args.config)
+    excluded_dirs = [
+        ".git",
+        "__pycache__",
+        ".venv",
+        "venv",
+        "**/.venv",
+        "**/__pycache__",
+    ] + args.exclude
+    inventory = hpysainv.collect_source_tests(
+        root,
+        patterns["python_files"],
+        patterns["python_classes"],
+        patterns["python_functions"],
+        excluded_dirs,
+    )
+    evidence = _read_evidence(args.pytest_input, root, args.pytest_cwd)
+    if args.collection_input:
+        collected = _read_evidence(args.collection_input, root, args.pytest_cwd)
+        # A separate complete inventory makes absent execution outcomes visible.
+        # Both captures must use the same code and selection configuration.
+        evidence = hpytsani.merge_evidence(collected, evidence)
+    report = hpytsani.analyze_inventory(inventory, evidence)
+    with open(args.output, "w", encoding="utf-8") as stream:
+        stream.write(_render_report(report, args.format))
+    _LOG.info("Wrote %d test records to '%s'", len(report["tests"]), args.output)
+    if inventory.errors or evidence.collection_errors:
+        return 2
+    failed_statuses = set(args.fail_on.split(","))
+    incomplete = (
+        not evidence.collection_complete or bool(inventory.uncertainties)
+    ) and "unknown" in failed_statuses
+    return int(
+        incomplete or bool(failed_statuses.intersection(report["summary"]))
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(_main(_parse()))

--- a/dev_scripts_helpers/testing/test/test_pytest_check_sanity.py
+++ b/dev_scripts_helpers/testing/test/test_pytest_check_sanity.py
@@ -3,6 +3,7 @@
 import json
 import os
 import shlex
+import subprocess
 import sys
 import unittest.mock as umock
 from typing import Any, Dict
@@ -194,3 +195,81 @@ class Test_pytest_check_sanity_py(hunitest.TestCase):
             report["tests"][0]["nodeid"], "check_a.py::verify_missing"
         )
         self.assertEqual(report["tests"][0]["status"], "not_collected")
+
+    def test5(self) -> None:
+        """Preserve real verbose skip reasons and call execution before teardown
+        errors.
+        """
+        root = self.get_scratch_space()
+        hio.to_file(os.path.join(root, "pytest.ini"), "[pytest]\n")
+        source = """
+        import pytest
+        def test_pass():
+            assert True
+        @pytest.mark.skip(reason="optional feature unavailable")
+        def test_skip():
+            pass
+        @pytest.mark.xfail(reason="known mismatch")
+        def test_xfail():
+            assert False
+        @pytest.fixture
+        def teardown_error():
+            yield
+            raise RuntimeError("fixture cleanup failed")
+        def test_teardown(teardown_error):
+            assert True
+        """
+        hio.to_file(
+            os.path.join(root, "test_outcomes.py"), hprint.dedent(source)
+        )
+        command = [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-vv",
+            "--color=no",
+            "--tb=short",
+        ]
+        result = subprocess.run(
+            command,
+            cwd=root,
+            env=dict(os.environ, PYTEST_DISABLE_PLUGIN_AUTOLOAD="1"),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 1)
+        input_path = os.path.join(root, "executed.log")
+        output_path = os.path.join(root, "sanity.json")
+        hio.to_file(input_path, result.stdout)
+        argv = [
+            "pytest_check_sanity.py",
+            "--pytest_input",
+            input_path,
+            "--code_input",
+            root,
+            "--pytest_cwd",
+            root,
+            "--output",
+            output_path,
+        ]
+        with umock.patch.object(sys, "argv", argv):
+            exit_code = dshtpchsa._main(dshtpchsa._parse())
+        self.assertEqual(exit_code, 1)
+        report = json.loads(hio.from_file(output_path))
+        self.assertEqual(
+            report["summary"],
+            {"error": 1, "passed": 1, "skipped": 1, "xfailed": 1},
+        )
+        self.assertTrue(report["collection_complete"])
+        cases = {item["nodeid"]: item for item in report["tests"]}
+        self.assertEqual(
+            cases["test_outcomes.py::test_skip"]["reason"],
+            "optional feature unavailable",
+        )
+        self.assertEqual(
+            cases["test_outcomes.py::test_xfail"]["reason"], "known mismatch"
+        )
+        self.assertTrue(
+            cases["test_outcomes.py::test_teardown"]["call_executed"]
+        )

--- a/dev_scripts_helpers/testing/test/test_pytest_check_sanity.py
+++ b/dev_scripts_helpers/testing/test/test_pytest_check_sanity.py
@@ -1,0 +1,196 @@
+"""Test the public pytest sanity checker with real files and pytest processes."""
+
+import json
+import os
+import shlex
+import sys
+import unittest.mock as umock
+from typing import Any, Dict
+
+import dev_scripts_helpers.testing.pytest_check_sanity as dshtpchsa
+import helpers.hio as hio
+import helpers.hprint as hprint
+import helpers.hsystem as hsystem
+import helpers.hunit_test as hunitest
+
+
+# #############################################################################
+# Test_pytest_check_sanity_py
+# #############################################################################
+
+
+class Test_pytest_check_sanity_py(hunitest.TestCase):
+    """Test `pytest_check_sanity.py` end to end."""
+
+    def helper(self, output_format: str) -> Dict[str, Any]:
+        """Run actual pytest collection and execution, then check saved
+        reports.
+        """
+        root = self.get_scratch_space()
+        config = os.path.join(root, "pytest.ini")
+        config_text = """
+        [pytest]
+        norecursedirs = omitted
+        """
+        hio.to_file(config, hprint.dedent(config_text))
+        source = """
+        def test_pass():
+            assert True
+        class TestGroup:
+            def test_method(self):
+                assert True
+        """
+        hio.to_file(os.path.join(root, "test_a.py"), hprint.dedent(source))
+        omitted_dir = os.path.join(root, "omitted")
+        os.makedirs(omitted_dir)
+        hidden_source = """
+        def test_missing():
+            assert True
+        """
+        hio.to_file(
+            os.path.join(omitted_dir, "test_hidden.py"),
+            hprint.dedent(hidden_source),
+        )
+        # Isolate the fixture's pytest run from this repository's plugins.
+        parts = [
+            shlex.quote(sys.executable),
+            "-m pytest",
+            "-c",
+            shlex.quote(config),
+            "--confcutdir",
+            shlex.quote(root),
+            "--rootdir",
+            shlex.quote(root),
+            "--color=no",
+            shlex.quote(root),
+        ]
+        command = "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 " + " ".join(parts)
+        rc, collected = hsystem.system_to_string(command + " --collect-only -q")
+        self.assertEqual(rc, 0)
+        rc, executed = hsystem.system_to_string(command + " -vv")
+        self.assertEqual(rc, 0)
+        collection_path = os.path.join(root, "collected.log")
+        execution_path = os.path.join(root, "executed.log")
+        output_path = os.path.join(root, "sanity." + output_format)
+        hio.to_file(collection_path, collected)
+        hio.to_file(execution_path, executed)
+        argv = [
+            "pytest_check_sanity.py",
+            "--pytest_input",
+            execution_path,
+            "--collection_input",
+            collection_path,
+            "--code_input",
+            root,
+            "--output",
+            output_path,
+            "--format",
+            output_format,
+        ]
+        with umock.patch.object(sys, "argv", argv):
+            exit_code = dshtpchsa._main(dshtpchsa._parse())
+        self.assertEqual(exit_code, 1)
+        output = hio.from_file(output_path)
+        return (
+            json.loads(output) if output_format == "json" else {"output": output}
+        )
+
+    def test1(self) -> None:
+        """Detect an omitted directory despite an otherwise passing real test
+        run.
+        """
+        # Prepare inputs.
+        output_format = "json"
+        expected = {"not_collected": 1, "passed": 2}
+        # Run test.
+        actual = self.helper(output_format)
+        # Check outputs.
+        self.assertEqual(actual["summary"], expected)
+        self.assertTrue(actual["collection_complete"])
+
+    def test2(self) -> None:
+        """Escape HTML-like node IDs and reasons in the standalone HTML
+        report.
+        """
+        # Prepare inputs.
+        report = {
+            "summary": {"skipped": 1},
+            "tests": [
+                {
+                    "status": "skipped",
+                    "nodeid": "test.py::test[<script>]",
+                    "reason": "a & b",
+                }
+            ],
+            "source_errors": {},
+            "collection_errors": {},
+            "warnings": [],
+        }
+        output_format = "html"
+        # Run test.
+        actual = dshtpchsa._render_report(report, output_format)
+        # Check outputs.
+        expected = (
+            '<!doctype html><html lang="en"><meta charset="utf-8">'
+            "<title>Pytest source sanity</title><body><pre>"
+            "Pytest source sanity\n\nSummary:\n  skipped: 1\n\nTests:\n"
+            "  skipped: test.py::test[&lt;script&gt;]\n    a &amp; b\n"
+            "</pre></body></html>\n"
+        )
+        self.assert_equal(actual, expected)
+
+    def test3(self) -> None:
+        """An empty, truncated capture cannot pass CI with an empty source
+        tree.
+        """
+        root = self.get_scratch_space()
+        input_path = os.path.join(root, "executed.log")
+        output_path = os.path.join(root, "sanity.json")
+        hio.to_file(input_path, "collecting ...\n")
+        argv = [
+            "pytest_check_sanity.py",
+            "--pytest_input",
+            input_path,
+            "--code_input",
+            root,
+            "--output",
+            output_path,
+        ]
+        with umock.patch.object(sys, "argv", argv):
+            actual = dshtpchsa._main(dshtpchsa._parse())
+        self.assertEqual(actual, 1)
+        report = json.loads(hio.from_file(output_path))
+        self.assertFalse(report["collection_complete"])
+
+    def test4(self) -> None:
+        """Custom naming rules still reveal a source test omitted from
+        collection.
+        """
+        root = self.get_scratch_space()
+        hio.to_file(
+            os.path.join(root, "pytest.ini"),
+            "[pytest]\npython_files = check_*.py\npython_functions = verify\n",
+        )
+        hio.to_file(
+            os.path.join(root, "check_a.py"), "def verify_missing(): pass\n"
+        )
+        input_path = os.path.join(root, "collected.log")
+        output_path = os.path.join(root, "sanity.json")
+        hio.to_file(input_path, "0 tests collected in 0.01s\n")
+        argv = [
+            "pytest_check_sanity.py",
+            "--pytest_input",
+            input_path,
+            "--code_input",
+            root,
+            "--output",
+            output_path,
+        ]
+        with umock.patch.object(sys, "argv", argv):
+            actual = dshtpchsa._main(dshtpchsa._parse())
+        self.assertEqual(actual, 1)
+        report = json.loads(hio.from_file(output_path))
+        self.assertEqual(
+            report["tests"][0]["nodeid"], "check_a.py::verify_missing"
+        )
+        self.assertEqual(report["tests"][0]["status"], "not_collected")

--- a/helpers/hpytest_sanity.py
+++ b/helpers/hpytest_sanity.py
@@ -1,0 +1,361 @@
+"""
+Compare source test inventories with pytest collection and execution evidence.
+
+Import as:
+
+import helpers.hpytest_sanity as hpytsani
+"""
+
+import dataclasses
+import logging
+import os
+import re
+from typing import Any, Dict, List, Optional
+
+import helpers.hdbg as hdbg
+import helpers.hpytest_sanity_inventory as hpysainv
+
+_LOG = logging.getLogger(__name__)
+
+
+# #############################################################################
+# PytestEvidence
+# #############################################################################
+
+
+@dataclasses.dataclass
+class PytestEvidence:
+    """
+    Preserve observed items separately from the completeness of the observation.
+
+    `items` includes individual parametrized node IDs. An absent outcome means
+    unexecuted, not skipped. `collection_complete` allows the analyzer to
+    distinguish a missing test from an incomplete input report.
+    """
+
+    root: str
+    items: Dict[str, Dict[str, Any]]
+    collection_errors: Dict[str, str]
+    collection_complete: bool
+    exit_code: int
+    warnings: List[str]
+    collection_skips: Dict[str, str] = dataclasses.field(default_factory=dict)
+
+
+# #############################################################################
+# Structured pytest evidence
+# #############################################################################
+
+
+def _get_stage_reason(test: Dict[str, Any]) -> str:
+    """Retain the reported skip or failure explanation from the relevant
+    stage.
+    """
+    _LOG.debug("Reading reason for nodeid='%s'", test.get("nodeid"))
+    reasons = []
+    for stage_name in ("setup", "call", "teardown"):
+        stage = test.get(stage_name, {})
+        # A teardown error can accompany a passed call, so retain both stages.
+        if stage.get("outcome") in ("failed", "skipped"):
+            reason = stage.get("longrepr", "")
+            if reason:
+                reasons.append(f"{stage_name}: {reason}")
+    return "\n".join(reasons)
+
+
+def parse_json_report(report: Dict[str, Any]) -> PytestEvidence:
+    """
+    Read a `pytest-json-report` object without importing the tested source.
+
+    :param report: decoded JSON report, including collectors and test stages
+    :return: observed item outcomes and collection-completeness evidence
+    """
+    _LOG.debug("Parsing report with keys=%s", sorted(report))
+    hdbg.dassert_isinstance(report.get("root"), str, "Report root is required")
+    hdbg.dassert_isinstance(
+        report.get("summary"), dict, "Report summary is required"
+    )
+    summary = report["summary"]
+    hdbg.dassert_isinstance(
+        report.get("exitcode"), int, "Report exit code is required"
+    )
+    exit_code = report["exitcode"]
+    collectors = report.get("collectors", [])
+    tests = report.get("tests", [])
+    hdbg.dassert_isinstance(collectors, list, "Collectors must be a list")
+    hdbg.dassert_isinstance(tests, list, "Tests must be a list")
+    # Collector IDs identify containers, including custom pytest collectors.
+    # All remaining result nodes are items; do not hardcode Function types.
+    collector_ids = {collector["nodeid"] for collector in collectors}
+    items: Dict[str, Dict[str, Any]] = {}
+    collection_errors = {}
+    collection_skips = {}
+    for collector in collectors:
+        if collector.get("outcome") == "failed":
+            collection_errors[collector["nodeid"]] = str(
+                collector.get("longrepr", collector["outcome"])
+            )
+        elif collector.get("outcome") == "skipped":
+            collection_skips[collector["nodeid"]] = str(
+                collector.get("longrepr", "skipped")
+            )
+        for result in collector.get("result", []):
+            nodeid = result["nodeid"]
+            if nodeid in collector_ids:
+                continue
+            items[nodeid] = {
+                "outcome": "deselected" if result.get("deselected") else "",
+                "reason": "",
+                "line": result.get("lineno", -1),
+                "call_executed": False,
+            }
+    # Runtime outcomes are useful even when xdist omits successful collectors.
+    collected_item_count = len(items)
+    for test in tests:
+        nodeid = test["nodeid"]
+        items[nodeid] = {
+            "outcome": test["outcome"],
+            "reason": _get_stage_reason(test),
+            "line": test.get("lineno", -1),
+            "call_executed": "call" in test,
+        }
+    # A summary is not an inventory. In particular, xdist and summary-only
+    # reports cannot establish that an unmentioned source test was not collected.
+    expected_count = summary.get("collected")
+    collection_complete = (
+        "collectors" in report
+        and isinstance(expected_count, int)
+        and collected_item_count == expected_count
+        and not collection_errors
+        and exit_code in (0, 1, 5)
+    )
+    warnings = []
+    if not collection_complete:
+        warnings.append(
+            "Collection inventory is incomplete or collection failed"
+        )
+    return PytestEvidence(
+        root=report["root"],
+        items=items,
+        collection_errors=collection_errors,
+        collection_complete=collection_complete,
+        exit_code=exit_code,
+        warnings=warnings,
+        collection_skips=collection_skips,
+    )
+
+
+# #############################################################################
+# Saved terminal evidence
+# #############################################################################
+
+
+def parse_terminal_report(
+    text: str, root: str, *, invocation_dir: Optional[str] = None
+) -> PytestEvidence:
+    """
+    Read verbose execution or flat `--collect-only -q` node-ID output.
+
+    :param text: saved pytest stdout with optional ANSI color sequences
+    :param root: node-ID root corresponding to the source inventory
+    :param invocation_dir: working directory of the original pytest process
+    :return: available evidence, with incomplete inventories explicitly marked
+    """
+    _LOG.debug("Parsing terminal report for root='%s'", root)
+    invocation_dir = os.path.abspath(invocation_dir or os.getcwd())
+    root = os.path.abspath(root)
+    text = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", text)
+    items: Dict[str, Dict[str, Any]] = {}
+    expected_count = -1
+    finished = False
+    errors = {}
+    # The greedy node group preserves spaces and outcome words in parameter IDs.
+    # Optional duration and percentage fields follow pytest's displayed node ID.
+    outcome_pattern = re.compile(
+        r"^(?P<node>.+?\.py::.+)\s+"
+        r"(?:\([\d.]+\s+s\)\s+)?"
+        r"(?P<outcome>PASSED|FAILED|SKIPPED|XFAIL|XPASS|ERROR|RERUN)"
+        r"(?:\s+\[\s*\d+%\])?(?:\s+\((?P<reason>.*)\))?\s*$"
+    )
+    for line in text.splitlines():
+        line = line.strip()
+        count = re.search(r"collected (\d+) items?", line)
+        flat_count = re.search(r"(\d+) tests? collected", line)
+        count_match = count or flat_count
+        if count_match is not None:
+            expected_count = int(count_match.group(1))
+        if flat_count or re.search(
+            r"=+ .*\d+ (passed|failed|skipped).* =+", line
+        ):
+            finished = True
+        match = outcome_pattern.match(line)
+        if match:
+            outcome = match.group("outcome").lower()
+            outcome = {"xfail": "xfailed", "xpass": "xpassed"}.get(
+                outcome, outcome
+            )
+            nodeid = match.group("node")
+            # This repository prefixes outcomes with elapsed times.
+            nodeid = re.sub(r"\s+\([\d.]+\s+s\)$", "", nodeid)
+            # Pytest's verbose terminal writer displays paths relative to its
+            # invocation directory, whereas flat collection uses rootdir.
+            path, separator, callable_name = nodeid.partition("::")
+            path = os.path.relpath(os.path.join(invocation_dir, path), root)
+            nodeid = path + separator + callable_name
+            items[nodeid] = {
+                "outcome": outcome,
+                "reason": match.group("reason") or "",
+                "line": -1,
+                "call_executed": outcome in ("passed", "failed", "xpassed"),
+            }
+        elif re.match(r"^[^<>]+\.py::\S", line) and not re.search(
+            r"\s+\[\s*\d+%\]", line
+        ):
+            # A bare flat collection ID contains no outcome or progress suffix.
+            if expected_count == -1 or not re.search(
+                r"\s+(PASSED|FAILED|ERROR)\b", line
+            ):
+                items.setdefault(
+                    line,
+                    {
+                        "outcome": "",
+                        "reason": "",
+                        "line": -1,
+                        "call_executed": False,
+                    },
+                )
+        if "ERROR collecting " in line:
+            errors[line.split("ERROR collecting ", 1)[1].strip(" _=")] = line
+    complete = finished and expected_count == len(items) and not errors
+    warnings = (
+        []
+        if complete
+        else ["Terminal log does not prove a complete collection inventory"]
+    )
+    return PytestEvidence(root, items, errors, complete, -1, warnings)
+
+
+# #############################################################################
+# Source-to-execution reconciliation
+# #############################################################################
+
+
+def merge_evidence(
+    collection: PytestEvidence, execution: PytestEvidence
+) -> PytestEvidence:
+    """
+    Combine matching captures without hiding contradictory collection evidence.
+
+    :param collection: full collection capture for the same revision and options
+    :param execution: saved execution capture
+    :return: merged evidence, preserving input objects
+    """
+    hdbg.dassert_eq(
+        os.path.abspath(collection.root),
+        os.path.abspath(execution.root),
+        "Collection and execution must have the same pytest root",
+    )
+    items = dict(collection.items)
+    items.update(execution.items)
+    errors = dict(collection.collection_errors)
+    errors.update(execution.collection_errors)
+    warnings = list(collection.warnings) + list(execution.warnings)
+    skips = dict(collection.collection_skips)
+    skips.update(execution.collection_skips)
+    unexpected = set(execution.items).difference(collection.items)
+    complete = collection.collection_complete and not unexpected and not errors
+    if unexpected:
+        warnings.append(
+            "Execution contains cases absent from the collection capture"
+        )
+    return PytestEvidence(
+        collection.root,
+        items,
+        errors,
+        complete,
+        execution.exit_code,
+        sorted(set(warnings)),
+        skips,
+    )
+
+
+def analyze_inventory(
+    inventory: hpysainv.SourceInventory, evidence: PytestEvidence
+) -> Dict[str, Any]:
+    """
+    Compare source definitions with observed individual pytest cases.
+
+    :param inventory: independently discovered source test definitions
+    :param evidence: observed collection and test outcomes
+    :return: deterministic report with cases, gaps, errors and summary counts
+    """
+    _LOG.debug(
+        "Analyzing %d source tests and %d cases",
+        len(inventory.tests),
+        len(evidence.items),
+    )
+    matched = set()
+    rows = []
+    for nodeid, item in sorted(evidence.items.items()):
+        # Only the callable portion is parametrized; brackets in a filename
+        # must not change how the source definition is resolved.
+        path, separator, callable_name = nodeid.partition("::")
+        source_id = path + separator + callable_name.split("[", 1)[0]
+        source = inventory.tests.get(source_id)
+        if source:
+            matched.add(source_id)
+        rows.append(
+            {
+                "nodeid": nodeid,
+                "status": item["outcome"] or "unexecuted",
+                "reason": item["reason"],
+                "source": source_id if source else "",
+                "line": source.line if source else item["line"] + 1,
+                "call_executed": item["call_executed"],
+            }
+        )
+    for nodeid, source in sorted(inventory.tests.items()):
+        if nodeid in matched:
+            continue
+        status = "not_collected" if evidence.collection_complete else "unknown"
+        reason = source.uncertain_reason
+        if source.uncertain_reason:
+            status = "unknown"
+        if source.excluded_reason:
+            status = "excluded"
+            reason = source.excluded_reason
+        for collector, skip_reason in evidence.collection_skips.items():
+            if nodeid == collector or nodeid.startswith(collector + "::"):
+                status, reason = "skipped", skip_reason
+                break
+        for collector, collector_reason in evidence.collection_errors.items():
+            if nodeid == collector or nodeid.startswith(collector + "::"):
+                status, reason = "collection_error", collector_reason
+                break
+        rows.append(
+            {
+                "nodeid": nodeid,
+                "status": status,
+                "reason": reason,
+                "source": nodeid,
+                "line": source.line,
+                "call_executed": False,
+            }
+        )
+    rows.sort(key=lambda row: row["nodeid"])
+    summary: Dict[str, int] = {}
+    for row in rows:
+        status = row["status"]
+        summary[status] = summary.get(status, 0) + 1
+    return {
+        "schema_version": 1,
+        "collection_complete": evidence.collection_complete,
+        "pytest_exit_code": evidence.exit_code,
+        "summary": dict(sorted(summary.items())),
+        "tests": rows,
+        "source_errors": dict(sorted(inventory.errors.items())),
+        "source_uncertainties": dict(sorted(inventory.uncertainties.items())),
+        "collection_errors": dict(sorted(evidence.collection_errors.items())),
+        "collection_skips": dict(sorted(evidence.collection_skips.items())),
+        "warnings": evidence.warnings,
+    }

--- a/helpers/hpytest_sanity.py
+++ b/helpers/hpytest_sanity.py
@@ -168,6 +168,7 @@ def parse_terminal_report(
     items: Dict[str, Dict[str, Any]] = {}
     expected_count = -1
     finished = False
+    reported_skips = 0
     errors = {}
     # The greedy node group preserves spaces and outcome words in parameter IDs.
     # Optional duration and percentage fields follow pytest's displayed node ID.
@@ -175,7 +176,8 @@ def parse_terminal_report(
         r"^(?P<node>.+?\.py::.+)\s+"
         r"(?:\([\d.]+\s+s\)\s+)?"
         r"(?P<outcome>PASSED|FAILED|SKIPPED|XFAIL|XPASS|ERROR|RERUN)"
-        r"(?:\s+\[\s*\d+%\])?(?:\s+\((?P<reason>.*)\))?\s*$"
+        r"(?:\s+\((?P<reason_before>.*)\))?"
+        r"(?:\s+\[\s*\d+%\])?(?:\s+\((?P<reason_after>.*)\))?\s*$"
     )
     for line in text.splitlines():
         line = line.strip()
@@ -184,10 +186,17 @@ def parse_terminal_report(
         count_match = count or flat_count
         if count_match is not None:
             expected_count = int(count_match.group(1))
+        if re.search(r"\bno tests collected\b", line):
+            expected_count = 0
+            finished = True
         if flat_count or re.search(
-            r"=+ .*\d+ (passed|failed|skipped).* =+", line
+            r"=+ .*?(\d+ (passed|failed|skipped|xfailed|xpassed|errors?|deselected)|no tests ran).* =+",
+            line,
         ):
             finished = True
+            skip_match = re.search(r"\b(\d+) skipped\b", line)
+            if skip_match:
+                reported_skips = int(skip_match.group(1))
         match = outcome_pattern.match(line)
         if match:
             outcome = match.group("outcome").lower()
@@ -204,16 +213,22 @@ def parse_terminal_report(
             nodeid = path + separator + callable_name
             items[nodeid] = {
                 "outcome": outcome,
-                "reason": match.group("reason") or "",
+                "reason": match.group("reason_before")
+                or match.group("reason_after")
+                or "",
                 "line": -1,
-                "call_executed": outcome in ("passed", "failed", "xpassed"),
+                "call_executed": outcome in ("passed", "failed", "xpassed")
+                or items.get(nodeid, {}).get("call_executed", False),
             }
         elif re.match(r"^[^<>]+\.py::\S", line) and not re.search(
             r"\s+\[\s*\d+%\]", line
         ):
             # A bare flat collection ID contains no outcome or progress suffix.
-            if expected_count == -1 or not re.search(
-                r"\s+(PASSED|FAILED|ERROR)\b", line
+            if not re.match(
+                r"^(PASSED|FAILED|SKIPPED|XFAIL|XPASS|ERROR|RERUN)\s", line
+            ) and (
+                expected_count == -1
+                or not re.search(r"\s+(PASSED|FAILED|ERROR)\b", line)
             ):
                 items.setdefault(
                     line,
@@ -226,7 +241,13 @@ def parse_terminal_report(
                 )
         if "ERROR collecting " in line:
             errors[line.split("ERROR collecting ", 1)[1].strip(" _=")] = line
-    complete = finished and expected_count == len(items) and not errors
+    observed_skips = sum(item["outcome"] == "skipped" for item in items.values())
+    complete = (
+        finished
+        and expected_count == len(items)
+        and not errors
+        and reported_skips <= observed_skips
+    )
     warnings = (
         []
         if complete

--- a/helpers/hpytest_sanity_inventory.py
+++ b/helpers/hpytest_sanity_inventory.py
@@ -1,0 +1,359 @@
+"""
+Inventory statically defined Python tests without importing test modules.
+
+Import as:
+
+import helpers.hpytest_sanity_inventory as hpysainv
+"""
+
+import ast
+import dataclasses
+import fnmatch
+import logging
+import os
+import tokenize
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+import helpers.hdbg as hdbg
+
+_LOG = logging.getLogger(__name__)
+_Function = Union[ast.FunctionDef, ast.AsyncFunctionDef]
+
+
+# #############################################################################
+# SourceTest
+# #############################################################################
+
+
+@dataclasses.dataclass
+class SourceTest:
+    """Represent one source definition, before parametrization produces cases."""
+
+    nodeid: str
+    path: str
+    line: int
+    excluded_reason: str
+    uncertain_reason: str = ""
+
+
+# #############################################################################
+# SourceInventory
+# #############################################################################
+
+
+@dataclasses.dataclass
+class SourceInventory:
+    """Keep source candidates separate from files that could not be analyzed."""
+
+    tests: Dict[str, SourceTest]
+    errors: Dict[str, str]
+    uncertainties: Dict[str, str] = dataclasses.field(default_factory=dict)
+
+
+# #############################################################################
+# AST inspection
+# #############################################################################
+
+
+def _matches(name: str, patterns: Sequence[str]) -> bool:
+    """Apply pytest's prefix-or-glob naming convention."""
+    return any(
+        fnmatch.fnmatchcase(name, pattern)
+        if any(char in pattern for char in "*?[")
+        else name.startswith(pattern)
+        for pattern in patterns
+    )
+
+
+def _name(node: ast.AST) -> str:
+    """Read a dotted name without evaluating arbitrary expressions."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return f"{_name(node.value)}.{node.attr}"
+    return ""
+
+
+def _is_disabled(body: List[ast.stmt]) -> bool:
+    """Recognize an explicit local `__test__ = False` assignment."""
+    disabled = False
+    for statement in body:
+        if isinstance(statement, ast.Assign):
+            names = [_name(target) for target in statement.targets]
+            if "__test__" in names:
+                disabled = (
+                    isinstance(statement.value, ast.Constant)
+                    and statement.value.value is False
+                )
+    return disabled
+
+
+def _class_test_flag(
+    node: ast.ClassDef,
+    classes: Dict[str, ast.ClassDef],
+    visited: Tuple[str, ...],
+) -> Optional[bool]:
+    """Resolve literal local or inherited `__test__` flags for simple class
+    trees.
+    """
+    if node.name in visited:
+        return None
+    local = None
+    for statement in node.body:
+        if isinstance(statement, ast.Assign):
+            if any(_name(target) == "__test__" for target in statement.targets):
+                if isinstance(statement.value, ast.Constant):
+                    local = bool(statement.value.value)
+    if local is not None:
+        return local
+    for base in node.bases:
+        base_name = _name(base)
+        if base_name in classes:
+            flag = _class_test_flag(
+                classes[base_name], classes, (*visited, node.name)
+            )
+            if flag is not None:
+                return flag
+    return None
+
+
+def _conditional_definitions(body: List[ast.stmt]) -> List[ast.stmt]:
+    """Enumerate definitions inside control flow, never inside function
+    bodies.
+    """
+    definitions = []
+    for statement in body:
+        if isinstance(
+            statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+        ):
+            definitions.append(statement)
+        else:
+            # Inspect statement-list children such as if/else and try/except.
+            # Expressions cannot contain Python test definitions.
+            for child in ast.iter_child_nodes(statement):
+                if isinstance(child, ast.stmt):
+                    definitions.extend(_conditional_definitions([child]))
+                elif isinstance(child, (ast.ExceptHandler, ast.match_case)):
+                    definitions.extend(_conditional_definitions(child.body))
+    return definitions
+
+
+def _class_methods(
+    node: ast.ClassDef,
+    classes: Dict[str, ast.ClassDef],
+    visited: Tuple[str, ...],
+) -> Tuple[Dict[str, _Function], bool]:
+    """Resolve local inherited methods, allowing subclasses to override them."""
+    methods: Dict[str, _Function] = {}
+    is_unittest = False
+    if node.name in visited:
+        return methods, is_unittest
+    visited = (*visited, node.name)
+    # Reverse bases so Python's leftmost base wins for simple inheritance.
+    # Runtime node IDs remain authoritative for more complex dynamic MROs.
+    for base in reversed(node.bases):
+        base_name = _name(base)
+        is_unittest = is_unittest or base_name.split(".")[-1] == "TestCase"
+        if base_name in classes:
+            inherited, base_is_unittest = _class_methods(
+                classes[base_name], classes, visited
+            )
+            methods.update(inherited)
+            is_unittest = is_unittest or base_is_unittest
+    for statement in node.body:
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            methods[statement.name] = statement
+        elif isinstance(statement, ast.Assign):
+            # A non-callable override masks an inherited test as well.
+            for target in statement.targets:
+                methods.pop(_name(target), None)
+        else:
+            for definition in _conditional_definitions([statement]):
+                if isinstance(
+                    definition, (ast.FunctionDef, ast.AsyncFunctionDef)
+                ):
+                    methods[definition.name] = definition
+    return methods, is_unittest
+
+
+def _inventory_module(
+    tree: ast.Module,
+    path: str,
+    class_patterns: Sequence[str],
+    function_patterns: Sequence[str],
+) -> Dict[str, SourceTest]:
+    """Inventory top-level functions and methods, including nested test
+    classes.
+    """
+    _LOG.debug("Inventorying path='%s'", path)
+    tests: Dict[str, SourceTest] = {}
+    definitions = _conditional_definitions(tree.body)
+    classes = {
+        statement.name: statement
+        for statement in definitions
+        if isinstance(statement, ast.ClassDef)
+    }
+    conditional_ids = {id(node) for node in definitions if node not in tree.body}
+    module_reason = "module __test__ = False" if _is_disabled(tree.body) else ""
+
+    def add(function: _Function, prefix: str, reason: str) -> None:
+        """Store a test candidate and explicit exclusion evidence."""
+        nodeid = f"{path}::{prefix}{function.name}"
+        for decorator in function.decorator_list:
+            target = (
+                decorator.func if isinstance(decorator, ast.Call) else decorator
+            )
+            if _name(target).split(".")[-1] == "fixture":
+                reason = reason or "fixture definition"
+        uncertainty = (
+            "conditional source definition"
+            if id(function) in conditional_ids
+            else ""
+        )
+        tests[nodeid] = SourceTest(
+            nodeid, path, function.lineno, reason, uncertainty
+        )
+
+    def visit_class(node: ast.ClassDef, prefix: str, reason: str) -> None:
+        """Inspect a class without descending into method bodies."""
+        methods, is_unittest = _class_methods(node, classes, ())
+        if not (is_unittest or _matches(node.name, class_patterns)):
+            return
+        if id(node) in conditional_ids:
+            conditional_ids.update(id(method) for method in methods.values())
+        conditional_ids.update(
+            id(method)
+            for method in _conditional_definitions(node.body)
+            if method not in node.body
+        )
+        reason = reason or (
+            "class __test__ = False"
+            if _class_test_flag(node, classes, ()) is False
+            else ""
+        )
+        if not is_unittest and "__init__" in methods:
+            reason = reason or "pytest class defines __init__"
+        if not is_unittest and "__new__" in methods:
+            reason = reason or "pytest class defines __new__"
+        class_prefix = f"{prefix}{node.name}::"
+        # unittest uses its own testMethodPrefix, not python_functions.
+        patterns = ("test",) if is_unittest else function_patterns
+        for name, method in methods.items():
+            if _matches(name, patterns):
+                add(method, class_prefix, reason)
+        if not is_unittest:
+            for statement in node.body:
+                if isinstance(statement, ast.ClassDef):
+                    visit_class(statement, class_prefix, reason)
+
+    for statement in definitions:
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if _matches(statement.name, function_patterns):
+                add(statement, "", module_reason)
+        elif isinstance(statement, ast.ClassDef):
+            visit_class(statement, "", module_reason)
+    return tests
+
+
+def _source_uncertainties(tree: ast.Module, path: str) -> Dict[str, str]:
+    """Expose constructs whose runtime test inventory cannot be proven
+    statically.
+    """
+    uncertainties = {}
+    definitions = _conditional_definitions(tree.body)
+    local_classes = {
+        node.name for node in definitions if isinstance(node, ast.ClassDef)
+    }
+    pending: List[ast.AST] = [tree]
+    while pending:
+        node = pending.pop()
+        # Function bodies run after collection and do not define module tests.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        pending.extend(ast.iter_child_nodes(node))
+        if isinstance(node, ast.ClassDef):
+            external = [
+                _name(base) or "computed base"
+                for base in node.bases
+                if _name(base) not in local_classes
+                and _name(base) not in ("object", "unittest.TestCase")
+            ]
+            if external or len(node.bases) > 1 or node.keywords:
+                uncertainties[f"{path}:{node.lineno}"] = (
+                    "Class inheritance or metaclass requires runtime resolution: "
+                    + node.name
+                )
+        if isinstance(node, ast.Call) and _name(node.func) in (
+            "exec",
+            "eval",
+            "setattr",
+            "globals",
+            "locals",
+            "type",
+        ):
+            uncertainties[f"{path}:{node.lineno}"] = (
+                "Potential dynamic test definition: " + _name(node.func)
+            )
+    return uncertainties
+
+
+# #############################################################################
+# Public inventory API
+# #############################################################################
+
+
+def collect_source_tests(
+    root: str,
+    file_patterns: Sequence[str],
+    class_patterns: Sequence[str],
+    function_patterns: Sequence[str],
+    excluded_dirs: Sequence[str],
+) -> SourceInventory:
+    """
+    Scan test source independently of pytest's collection exclusions.
+
+    :param root: code directory used as the relative node-ID root
+    :param file_patterns: pytest `python_files` glob patterns
+    :param class_patterns: pytest `python_classes` prefixes or globs
+    :param function_patterns: pytest `python_functions` prefixes or globs
+    :param excluded_dirs: inventory-only directory globs, relative to `root`
+    :return: source candidates and explicit parse/read error diagnostics
+    """
+    _LOG.debug("Scanning source root='%s'", root)
+    hdbg.dassert_dir_exists(root, "Source inventory requires a directory")
+    tests: Dict[str, SourceTest] = {}
+    errors = {}
+    uncertainties = {}
+    for directory, directories, files in os.walk(root, followlinks=False):
+        # Do not silently mirror pytest norecursedirs: omitted tests are the
+        # very evidence this inventory is intended to discover.
+        directories[:] = sorted(
+            name
+            for name in directories
+            if not any(
+                fnmatch.fnmatchcase(
+                    os.path.relpath(os.path.join(directory, name), root), pattern
+                )
+                for pattern in excluded_dirs
+            )
+        )
+        for filename in sorted(files):
+            if not any(
+                fnmatch.fnmatchcase(filename, pat) for pat in file_patterns
+            ):
+                continue
+            full_path = os.path.join(directory, filename)
+            path = os.path.relpath(full_path, root).replace(os.sep, "/")
+            # Syntax failures are reported as missing evidence, never treated
+            # as an empty module. No source code is executed during the scan.
+            try:
+                with tokenize.open(full_path) as stream:
+                    tree = ast.parse(stream.read(), filename=path)
+            except (SyntaxError, UnicodeError, OSError) as error:
+                errors[path] = str(error)
+                continue
+            tests.update(
+                _inventory_module(tree, path, class_patterns, function_patterns)
+            )
+            uncertainties.update(_source_uncertainties(tree, path))
+    return SourceInventory(tests, errors, uncertainties)

--- a/helpers/test/test_hpytest_sanity.py
+++ b/helpers/test/test_hpytest_sanity.py
@@ -1,0 +1,336 @@
+"""Test pytest evidence ingestion for the source-to-execution sanity checker."""
+
+import copy
+import pprint
+from typing import Any, Dict
+
+import helpers.hpytest_sanity as hpytsani
+import helpers.hpytest_sanity_inventory as hpysainv
+import helpers.hprint as hprint
+import helpers.hunit_test as hunitest
+
+
+# #############################################################################
+# Test_parse_json_report
+# #############################################################################
+
+
+class Test_parse_json_report(hunitest.TestCase):
+    """Test `helpers.hpytest_sanity.parse_json_report()`."""
+
+    def helper(self) -> Dict[str, Any]:
+        """Build a report with two collected cases and one completed case."""
+        report = {
+            "root": "/fixture",
+            "exitcode": 0,
+            "summary": {"collected": 2},
+            "collectors": [
+                {
+                    "nodeid": "test_a.py",
+                    "outcome": "passed",
+                    "result": [
+                        {
+                            "nodeid": "test_a.py::test1[first [case]]",
+                            "lineno": 1,
+                        },
+                        {"nodeid": "test_a.py::test1[second case]", "lineno": 1},
+                    ],
+                }
+            ],
+            "tests": [
+                {
+                    "nodeid": "test_a.py::test1[first [case]]",
+                    "lineno": 1,
+                    "outcome": "passed",
+                    "call": {"outcome": "passed"},
+                }
+            ],
+        }
+        return copy.deepcopy(report)
+
+    def test5(self) -> None:
+        """A module-level skip is intentional skip evidence, not a collection
+        error.
+        """
+        report = {
+            "root": "/fixture",
+            "exitcode": 5,
+            "summary": {"collected": 0},
+            "collectors": [
+                {
+                    "nodeid": "test_a.py",
+                    "outcome": "skipped",
+                    "longrepr": "optional dependency unavailable",
+                }
+            ],
+            "tests": [],
+        }
+        source = hpysainv.SourceTest("test_a.py::test1", "test_a.py", 1, "")
+        inventory = hpysainv.SourceInventory({source.nodeid: source}, {})
+        evidence = hpytsani.parse_json_report(report)
+        actual = hpytsani.analyze_inventory(inventory, evidence)
+        self.assertEqual(actual["tests"][0]["status"], "skipped")
+        self.assertEqual(
+            actual["tests"][0]["reason"], "optional dependency unavailable"
+        )
+        self.assertEqual(len(actual["collection_errors"]), 0)
+
+    def test1(self) -> None:
+        """Preserve parameter IDs and leave unexecuted outcomes unset."""
+        # Prepare inputs.
+        report = self.helper()
+        # Prepare outputs.
+        expected = {
+            "test_a.py::test1[first [case]]": {
+                "outcome": "passed",
+                "reason": "",
+                "line": 1,
+                "call_executed": True,
+            },
+            "test_a.py::test1[second case]": {
+                "outcome": "",
+                "reason": "",
+                "line": 1,
+                "call_executed": False,
+            },
+        }
+        # Run test.
+        actual = hpytsani.parse_json_report(report)
+        # Check outputs.
+        self.assert_equal(pprint.pformat(actual.items), pprint.pformat(expected))
+        self.assertTrue(actual.collection_complete)
+
+    def test2(self) -> None:
+        """Keep runtime skip reasons separate from deselected items."""
+        # Prepare inputs.
+        report = self.helper()
+        report["collectors"][0]["result"][1]["deselected"] = True
+        report["tests"][0].pop("call")
+        report["tests"][0]["outcome"] = "skipped"
+        report["tests"][0]["setup"] = {
+            "outcome": "skipped",
+            "longrepr": "maintenance window",
+        }
+        # Prepare outputs.
+        expected = [
+            ("skipped", "setup: maintenance window", False),
+            ("deselected", "", False),
+        ]
+        # Run test.
+        evidence = hpytsani.parse_json_report(report)
+        actual = [
+            (item["outcome"], item["reason"], item["call_executed"])
+            for item in evidence.items.values()
+        ]
+        # Check outputs.
+        self.assert_equal(pprint.pformat(actual), pprint.pformat(expected))
+
+    def test3(self) -> None:
+        """A runtime-only report does not prove collection completeness."""
+        # Prepare inputs.
+        report = self.helper()
+        report.pop("collectors")
+        # Run test.
+        evidence = hpytsani.parse_json_report(report)
+        # Check outputs.
+        self.assertFalse(evidence.collection_complete)
+        self.assertEqual(len(evidence.items), 1)
+
+    def test4(self) -> None:
+        """Collection failures and interrupted runs are incomplete evidence."""
+        # Prepare inputs.
+        report = self.helper()
+        report["exitcode"] = 2
+        report["collectors"].append(
+            {
+                "nodeid": "test_b.py",
+                "outcome": "failed",
+                "longrepr": "syntax error",
+            }
+        )
+        expected = {"test_b.py": "syntax error"}
+        # Run test.
+        evidence = hpytsani.parse_json_report(report)
+        # Check outputs.
+        self.assertFalse(evidence.collection_complete)
+        self.assert_equal(
+            pprint.pformat(evidence.collection_errors), pprint.pformat(expected)
+        )
+
+
+# #############################################################################
+# Test_analyze_inventory
+# #############################################################################
+
+
+class Test_analyze_inventory(hunitest.TestCase):
+    """Test source-to-execution reconciliation."""
+
+    def helper(self, complete: bool) -> Dict[str, Any]:
+        """Analyze one omitted source test and one executed parameter case."""
+        definitions = {
+            name: hpysainv.SourceTest(name, name.split("::")[0], 1, "")
+            for name in ("test_a.py::test1", "ignored/test_b.py::test2")
+        }
+        inventory = hpysainv.SourceInventory(definitions, {})
+        items = {
+            "test_a.py::test1[case [one]]": {
+                "outcome": "passed",
+                "reason": "",
+                "line": 0,
+                "call_executed": True,
+            }
+        }
+        evidence = hpytsani.PytestEvidence(
+            "/fixture", items, {}, complete, 0, []
+        )
+        return hpytsani.analyze_inventory(inventory, evidence)
+
+    def test1(self) -> None:
+        """A complete inventory distinguishes omitted source tests from cases."""
+        # Prepare inputs.
+        complete = True
+        expected = {"not_collected": 1, "passed": 1}
+        # Run test.
+        actual = self.helper(complete)
+        # Check outputs.
+        self.assert_equal(
+            pprint.pformat(actual["summary"]), pprint.pformat(expected)
+        )
+
+    def test2(self) -> None:
+        """Incomplete collection does not prove a missing source test was
+        omitted.
+        """
+        # Prepare inputs.
+        complete = False
+        expected = {"passed": 1, "unknown": 1}
+        # Run test.
+        actual = self.helper(complete)
+        # Check outputs.
+        self.assert_equal(
+            pprint.pformat(actual["summary"]), pprint.pformat(expected)
+        )
+
+
+# #############################################################################
+# Test_parse_terminal_report
+# #############################################################################
+
+
+class Test_parse_terminal_report(hunitest.TestCase):
+    """Test saved pytest flat collection and verbose execution output."""
+
+    def helper(self, text: str) -> hpytsani.PytestEvidence:
+        """Parse a saved log relative to a fixed source root."""
+        text = hprint.dedent(text)
+        root = "/fixture"
+        return hpytsani.parse_terminal_report(text, root, invocation_dir=root)
+
+    def test1(self) -> None:
+        """Flat collection retains spaces and brackets in parametrized IDs."""
+        # Prepare inputs.
+        text = """
+        test_a.py::test1[first [case]]
+        test_a.py::test1[second case]
+        2 tests collected in 0.01s
+        """
+        expected = [
+            "test_a.py::test1[first [case]]",
+            "test_a.py::test1[second case]",
+        ]
+        # Run test.
+        actual = self.helper(text)
+        # Check outputs.
+        self.assertTrue(actual.collection_complete)
+        self.assert_equal(
+            pprint.pformat(sorted(actual.items)), pprint.pformat(expected)
+        )
+
+    def test2(self) -> None:
+        """Read the repository's duration prefix without altering node
+        identity.
+        """
+        # Prepare inputs.
+        text = """
+        collected 1 item
+        test_a.py::TestOne::test1 (0.02 s) PASSED [100%]
+        ==================== 1 passed in 0.02s ====================
+        """
+        expected = ["test_a.py::TestOne::test1"]
+        # Run test.
+        actual = self.helper(text)
+        # Check outputs.
+        self.assertTrue(actual.collection_complete)
+        self.assert_equal(
+            pprint.pformat(sorted(actual.items)), pprint.pformat(expected)
+        )
+
+    def test3(self) -> None:
+        """A truncated execution log does not prove all tests were observed."""
+        # Prepare inputs.
+        text = """
+        collected 2 items
+        test_a.py::test1 PASSED [50%]
+        """
+        # Run test.
+        actual = self.helper(text)
+        # Check outputs.
+        self.assertFalse(actual.collection_complete)
+        self.assertEqual(len(actual.items), 1)
+
+    def test4(self) -> None:
+        """Normalize verbose paths using the original process working
+        directory.
+        """
+        text = "collected 1 item\nfixture/test_a.py::test1 PASSED [100%]\n=== 1 passed in 0.01s ==="
+        actual = hpytsani.parse_terminal_report(
+            text, "/repo/fixture", invocation_dir="/repo"
+        )
+        self.assertTrue(actual.collection_complete)
+        self.assert_equal(
+            pprint.pformat(list(actual.items)), "['test_a.py::test1']"
+        )
+
+
+# #############################################################################
+# Test_merge_evidence
+# #############################################################################
+
+
+class Test_merge_evidence(hunitest.TestCase):
+    """Test contradictory captures and preservation of unexecuted cases."""
+
+    def test1(self) -> None:
+        """A missing execution outcome remains unexecuted after
+        reconciliation.
+        """
+        collection = hpytsani.parse_terminal_report(
+            "test_a.py::test1\ntest_a.py::test2\n2 tests collected in 0.01s",
+            "/fixture",
+        )
+        execution = hpytsani.parse_terminal_report(
+            "collected 2 items\ntest_a.py::test1 PASSED [50%]",
+            "/fixture",
+            invocation_dir="/fixture",
+        )
+        actual = hpytsani.merge_evidence(collection, execution)
+        self.assertTrue(actual.collection_complete)
+        self.assertEqual(actual.items["test_a.py::test2"]["outcome"], "")
+        self.assertEqual(collection.items["test_a.py::test1"]["outcome"], "")
+
+    def test2(self) -> None:
+        """Different selected cases must not establish a complete merged
+        capture.
+        """
+        collection = hpytsani.parse_terminal_report(
+            "test_a.py::test1\n1 test collected", "/fixture"
+        )
+        execution = hpytsani.parse_terminal_report(
+            "collected 1 item\ntest_a.py::test2 PASSED [100%]\n=== 1 passed in 0.01s ===",
+            "/fixture",
+            invocation_dir="/fixture",
+        )
+        actual = hpytsani.merge_evidence(collection, execution)
+        self.assertFalse(actual.collection_complete)
+        self.assertEqual(len(actual.items), 2)

--- a/helpers/test/test_hpytest_sanity.py
+++ b/helpers/test/test_hpytest_sanity.py
@@ -227,6 +227,34 @@ class Test_parse_terminal_report(hunitest.TestCase):
         root = "/fixture"
         return hpytsani.parse_terminal_report(text, root, invocation_dir=root)
 
+    def test5(self) -> None:
+        """Recognize a finished run containing only expected failures."""
+        text = """
+        collected 1 item
+        test_a.py::test1 XFAIL (known mismatch) [100%]
+        ==================== 1 xfailed in 0.01s ====================
+        """
+        actual = self.helper(text)
+        self.assertTrue(actual.collection_complete)
+        self.assertEqual(
+            actual.items["test_a.py::test1"]["reason"], "known mismatch"
+        )
+
+    def test6(self) -> None:
+        """An explicit empty collection footer differs from a truncated log."""
+        actual = self.helper("no tests collected in 0.01s")
+        self.assertTrue(actual.collection_complete)
+        self.assertEqual(len(actual.items), 0)
+
+    def test7(self) -> None:
+        """An unnamed module skip does not prove source tests were omitted."""
+        text = """
+        collected 0 items / 1 skipped
+        ==================== 1 skipped in 0.01s ====================
+        """
+        actual = self.helper(text)
+        self.assertFalse(actual.collection_complete)
+
     def test1(self) -> None:
         """Flat collection retains spaces and brackets in parametrized IDs."""
         # Prepare inputs.

--- a/helpers/test/test_hpytest_sanity_inventory.py
+++ b/helpers/test/test_hpytest_sanity_inventory.py
@@ -1,0 +1,179 @@
+"""Test the independent source inventory used by the pytest sanity checker."""
+
+import os
+import pprint
+from typing import Dict
+
+import helpers.hio as hio
+import helpers.hprint as hprint
+import helpers.hpytest_sanity_inventory as hpysainv
+import helpers.hunit_test as hunitest
+
+
+# #############################################################################
+# Test_collect_source_tests
+# #############################################################################
+
+
+class Test_collect_source_tests(hunitest.TestCase):
+    """Test `helpers.hpytest_sanity_inventory.collect_source_tests()`."""
+
+    def helper(self, files: Dict[str, str]) -> hpysainv.SourceInventory:
+        """Write a real source tree and scan it without importing modules."""
+        root = self.get_scratch_space()
+        for path, content in files.items():
+            full_path = os.path.join(root, path)
+            os.makedirs(os.path.dirname(full_path), exist_ok=True)
+            hio.to_file(full_path, hprint.dedent(content))
+        file_patterns = ("test_*.py", "*_test.py")
+        class_patterns = ("Test",)
+        function_patterns = ("test",)
+        excluded_dirs = (".git",)
+        return hpysainv.collect_source_tests(
+            root, file_patterns, class_patterns, function_patterns, excluded_dirs
+        )
+
+    def test1(self) -> None:
+        """Find tests in omitted directories without executing module code."""
+        # Prepare inputs.
+        files = {
+            "omitted/test_a.py": """
+            raise RuntimeError('must not import')
+            def test1():
+                def test_local():
+                    pass
+            async def test2():
+                pass
+            class TestOuter:
+                def test3(self):
+                    pass
+                class TestInner:
+                    def test4(self):
+                        pass
+            """
+        }
+        expected = [
+            "omitted/test_a.py::TestOuter::TestInner::test4",
+            "omitted/test_a.py::TestOuter::test3",
+            "omitted/test_a.py::test1",
+            "omitted/test_a.py::test2",
+        ]
+        # Run test.
+        actual = self.helper(files)
+        # Check outputs.
+        self.assert_equal(
+            pprint.pformat(sorted(actual.tests)), pprint.pformat(expected)
+        )
+        self.assertEqual(len(actual.errors), 0)
+
+    def test2(self) -> None:
+        """Preserve local inherited methods and explicit disabled classes."""
+        # Prepare inputs.
+        files = {
+            "test_a.py": """
+            import unittest
+            class Base:
+                def test_inherited(self):
+                    pass
+            class TestChild(Base):
+                def test_own(self):
+                    pass
+            class Legacy(unittest.TestCase):
+                def test_old(self):
+                    pass
+            class TestDisabled:
+                __test__ = False
+                def test_hidden(self):
+                    pass
+            """
+        }
+        expected = {
+            "test_a.py::Legacy::test_old": "",
+            "test_a.py::TestChild::test_inherited": "",
+            "test_a.py::TestChild::test_own": "",
+            "test_a.py::TestDisabled::test_hidden": "class __test__ = False",
+        }
+        # Run test.
+        inventory = self.helper(files)
+        actual = {
+            key: value.excluded_reason for key, value in inventory.tests.items()
+        }
+        # Check outputs.
+        self.assert_equal(pprint.pformat(actual), pprint.pformat(expected))
+
+    def test5(self) -> None:
+        """Expose imported inheritance and dynamic module definitions as
+        uncertain.
+        """
+        files = {
+            "test_a.py": """
+            from external import Base
+            class TestImported(Base):
+                def test_local(self):
+                    setattr(self, 'value', 1)
+            globals()['test_generated'] = lambda: None
+            """
+        }
+        actual = self.helper(files)
+        self.assertEqual(len(actual.uncertainties), 2)
+        self.assertEqual(len(actual.tests), 1)
+
+    def test6(self) -> None:
+        """Discover conditional class methods without executing their
+        conditions.
+        """
+        files = {
+            "test_a.py": """
+            class TestConditional:
+                if feature_enabled:
+                    def test_optional(self):
+                        pass
+            """
+        }
+        actual = self.helper(files)
+        self.assertEqual(
+            actual.tests[
+                "test_a.py::TestConditional::test_optional"
+            ].uncertain_reason,
+            "conditional source definition",
+        )
+
+    def test3(self) -> None:
+        """Report syntax errors without losing valid files in the same tree."""
+        # Prepare inputs.
+        files = {
+            "test_bad.py": "def invalid(:",
+            "test_good.py": "def test1(): pass",
+        }
+        expected = (["test_good.py::test1"], ["test_bad.py"])
+        # Run test.
+        inventory = self.helper(files)
+        actual = (sorted(inventory.tests), sorted(inventory.errors))
+        # Check outputs.
+        self.assert_equal(pprint.pformat(actual), pprint.pformat(expected))
+
+    def test4(self) -> None:
+        """Retain conditional tests without asserting the branch was executed."""
+        # Prepare inputs.
+        files = {
+            "test_a.py": """
+            if unknown_feature:
+                def test_conditional():
+                    pass
+            else:
+                class TestConditional:
+                    def test_method(self):
+                        pass
+            """
+        }
+        expected = {
+            "test_a.py::TestConditional::test_method": "conditional source definition",
+            "test_a.py::test_conditional": "conditional source definition",
+        }
+        # Run test.
+        inventory = self.helper(files)
+        actual = {
+            key: item.uncertain_reason for key, item in inventory.tests.items()
+        }
+        # Check outputs.
+        self.assert_equal(pprint.pformat(actual), pprint.pformat(expected))


### PR DESCRIPTION
Related to #1362.

I've added `pytest_check_sanity.py` to compare an independent source test inventory with saved pytest collection and execution results. A passing test run can still omit tests through directory exclusions or selection; this tool makes those gaps visible alongside skips, deselections, and collected cases without execution outcomes.

The implementation includes:

- An AST inventory that reads test definitions without importing their modules and respects pytest naming configuration.
- Adapters for pytest-json-report, flat collection logs, and verbose execution logs, preserving individual parameter IDs and available skip reasons.
- Reconciliation that identifies incomplete or contradictory captures and retains evidence of call execution when teardown fails.
- Deterministic JSON, text, and escaped HTML reports, configurable CI failures, and inventory exclusions.
- Usage examples, architecture notes, configuration guidance, and documented static-analysis limits.

Imported inheritance, complex class resolution, conditional definitions, and potential dynamic test generation remain explicit uncertainties. The tool does not claim that static analysis can prove the complete runtime inventory of arbitrary Python.

Validation:

- 71 tests pass across the three new test modules and existing `helpers/test/test_hpytest.py` regressions. The end-to-end fixtures run real pytest collection and execution, including an omitted directory and a mixed pass, skip, expected-failure, and teardown-error run.
- Pyright reports zero errors or warnings across the six new Python files.
- Local repository Python pre-commit hooks pass, including Ruff, ssort, and docformatter. I also ran import normalization, class-frame formatting, and comment formatting.
- With tracemalloc enabled, the scanner processed 20,000 definitions across 1,000 synthetic files in 0.310s with 4.08 MiB peak traced allocation. A repository checkpoint found 4,475 definitions in 0.879s with 7.52 MiB peak traced allocation. These are local measurements, not CI guarantees.

I attempted the standard `invoke lint` container workflow. The wrapper expanded `--files` into separate arguments, so I used `--from-file`. The public `causify/helpers:prod` image then lacked `pre-commit` and `uv`, and its Pyright wrapper failed while decoding its output. The local Python checks above pass; full container and Markdown lint remain unverified.

I couldn't set reviewer or author assignments through GitHub. Please help assign a reviewer and apply the review label. No GitHub checks were reported at the last verification.

First-review checklist:

- [x] Branch follows `RelatedIssueTag_Normalized_issue_title`.
- [x] Commit messages are short and informative with the issue tag.
- [x] PR title matches the branch name.
- [x] Description explains the change and mentions the related issue.
- [x] No closing keyword links the issue under Development.
- [ ] Reviewer assignment is verified.
- [ ] Author assignment is verified.
- [ ] All GitHub Actions checks pass.
- [x] Branch started from current master, with no conflicts at submission.
- [x] No temporary/log files or files larger than 500 KB are included.
- [ ] All standard container lint checks pass; limitations are recorded above.
- [x] No screenshots are used for errors or review evidence.
- [ ] Review label is present.
- [ ] Review comments are addressed consistently and conversations resolved.
