### PR TITLE
Helpers1374: linter stage to find public functions that should be private

### DIFF
--- a/linters/amp_check_private_functions.py
+++ b/linters/amp_check_private_functions.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python
+"""
+Find public functions that are only used within their defining file.
+
+A public module-level function (i.e., a function whose name does not start
+with "_") that is never referenced outside of the file where it is defined
+should be private, meaning that its name should start with "_".
+
+The check is static and conservative:
+
+- definitions and usages are collected through `ast` parsing;
+- a function is flagged only when every usage of its name within the
+  searched code is inside its defining file; a function with no usage at
+  all is flagged as well;
+- any identifier with the same name in another file counts as a usage, so
+  that dynamic references cause false negatives instead of false positives.
+
+Note: usages are searched in the repository of the linted file (or in the
+dirs passed through `--search_dirs`), so a function that is used only by
+other repos is still reported; in that case the function should remain
+public.
+
+# Usage example
+
+- Find the functions that should be private:
+> amp_check_private_functions.py sample_file1.py sample_file2.py
+
+- Search for usages also in other dirs:
+> amp_check_private_functions.py --search_dirs "/src/repo1,/src/repo2" sample_file1.py
+
+- Rename the flagged functions (and their usages within the defining file)
+  to make them private:
+> amp_check_private_functions.py --fix sample_file1.py
+
+Import as:
+
+import linters.amp_check_private_functions as lamchprfu
+"""
+
+import argparse
+import ast
+import logging
+import os
+import re
+from typing import Dict, List, Optional, Tuple
+
+import helpers.hdbg as hdbg
+import helpers.hgit as hgit
+import helpers.hio as hio
+import helpers.hparser as hparser
+import linters.action as liaction
+import linters.utils as liutils
+
+_LOG = logging.getLogger(__name__)
+
+# Map of usages by name: name -> file -> [(line number, column)].
+_UsageMap = Dict[str, Dict[str, List[Tuple[int, int]]]]
+
+
+# #############################################################################
+# Functions that should be private
+# #############################################################################
+
+
+def _is_public_function(name: str) -> bool:
+    """
+    Return whether a function name is considered public.
+    """
+    ret = not name.startswith("_") and name != "main"
+    return ret
+
+
+def _is_dynamically_called(node: ast.AST) -> bool:
+    """
+    Return whether a function node is invoked dynamically through a
+    decorator.
+
+    E.g., the functions decorated with `@task` are called by `invoke` and
+    not (only) from the code, so they must stay public.
+    """
+    for decorator in getattr(node, "decorator_list", []):
+        target: Optional[ast.AST] = decorator
+        if isinstance(target, ast.Call):
+            target = target.func
+        if isinstance(target, ast.Name) and target.id == "task":
+            return True
+        if isinstance(target, ast.Attribute) and target.attr == "task":
+            return True
+    return False
+
+
+def _is_exported(tree: ast.Module, name: str) -> bool:
+    """
+    Return whether a name is listed in the `__all__` of a module.
+    """
+    for node in tree.body:
+        targets: List[ast.AST] = []
+        value: Optional[ast.AST] = None
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            value = node.value
+        if value is None:
+            continue
+        if not any(
+            isinstance(t, ast.Name) and t.id == "__all__" for t in targets
+        ):
+            continue
+        if isinstance(value, (ast.List, ast.Tuple, ast.Set)):
+            for elem in value.elts:
+                if (
+                    isinstance(elem, ast.Constant)
+                    and isinstance(elem.value, str)
+                    and elem.value == name
+                ):
+                    return True
+    return False
+
+
+def _get_public_functions(file_name: str) -> List[Tuple[str, int]]:
+    """
+    Get the public module-level functions defined in a file.
+
+    :return: list of (function name, line number of the definition)
+    """
+    source = hio.from_file(file_name)
+    tree = ast.parse(source)
+    funcs = []
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not _is_public_function(node.name):
+            continue
+        if _is_dynamically_called(node):
+            continue
+        if _is_exported(tree, node.name):
+            continue
+        funcs.append((node.name, node.lineno))
+    return funcs
+
+
+# #############################################################################
+# Usages
+# #############################################################################
+
+
+def _get_py_files(search_dir: str) -> List[str]:
+    """
+    Get all the Python files under a directory, skipping hidden dirs.
+
+    Note: the files in the `tmp.scratch` dirs are skipped since they are
+    temporary.
+    """
+    py_files = []
+    for root, dirs, file_names in os.walk(search_dir):
+        dirs[:] = [
+            d
+            for d in dirs
+            if not d.startswith(".")
+            and d != "tmp.scratch"
+            and not d.endswith(".egg-info")
+        ]
+        for file_name in file_names:
+            if file_name.endswith(".py"):
+                py_files.append(os.path.join(root, file_name))
+    return py_files
+
+
+def _collect_usages(search_dir: str) -> _UsageMap:
+    """
+    Collect the identifier usages of all the Python files under a dir.
+
+    Usages are both plain names (e.g., a call `foo()`) and attributes
+    (e.g., a call `module.foo()`).
+
+    :return: map of usages in the format `_UsageMap`
+    """
+    usages: _UsageMap = {}
+    for py_file in _get_py_files(search_dir):
+        py_file = os.path.abspath(py_file)
+        source = hio.from_file(py_file)
+        try:
+            tree = ast.parse(source)
+        except SyntaxError as ex:
+            _LOG.debug("Could not parse file '%s': %s", py_file, ex)
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Name):
+                name = node.id
+            elif isinstance(node, ast.Attribute):
+                name = node.attr
+            else:
+                continue
+            file_usages = usages.setdefault(name, {})
+            file_usages.setdefault(py_file, []).append(
+                (node.lineno, node.col_offset)
+            )
+    return usages
+
+
+def _find_private_function_candidates(
+    file_name: str, usages: _UsageMap
+) -> List[Tuple[str, int]]:
+    """
+    Find the public functions of a file that are only used within it.
+
+    A function is a candidate when every usage of its name within the
+    searched code is inside its defining file; functions with no usage at
+    all are candidates as well.
+
+    :param usages: map of usages in the format `_UsageMap`
+    :return: list of (function name, line number of the definition)
+    """
+    file_name = os.path.abspath(file_name)
+    candidates = []
+    for name, line_num in _get_public_functions(file_name):
+        locs = usages.get(name, {})
+        is_used_externally = any(loc_file != file_name for loc_file in locs)
+        if is_used_externally:
+            continue
+        candidates.append((name, line_num))
+    return candidates
+
+
+# #############################################################################
+# _CheckPrivateFunctions
+# #############################################################################
+
+
+class _CheckPrivateFunctions(liaction.Action):
+    """
+    Check for public functions that are only used within their defining
+    file.
+    """
+
+    def __init__(self, search_dirs: Optional[List[str]] = None) -> None:
+        super().__init__()
+        self._search_dirs = search_dirs
+        self._usages: Optional[_UsageMap] = None
+
+    def check_if_possible(self) -> bool:
+        return True
+
+    def _execute(self, file_name: str, pedantic: int) -> List[str]:
+        _ = pedantic
+        if self.skip_if_not_py(file_name):
+            # Apply only to Python files.
+            return []
+        if liutils.is_init_py(file_name) or liutils.is_test_code(file_name):
+            return []
+        if self._usages is None:
+            search_dirs = self._search_dirs
+            if search_dirs is None:
+                search_dirs = [_get_repo_root(file_name)]
+            _LOG.debug("Collecting usages from %s dir(s)", len(search_dirs))
+            usages: _UsageMap = {}
+            for search_dir in search_dirs:
+                cur_usages = _collect_usages(search_dir)
+                for name, locs in cur_usages.items():
+                    file_usages = usages.setdefault(name, {})
+                    for loc_file, positions in locs.items():
+                        file_usages.setdefault(loc_file, []).extend(positions)
+            self._usages = usages
+        candidates = _find_private_function_candidates(file_name, self._usages)
+        output = [
+            f"{file_name}:{line_num}: the function '{name}' is only used"
+            f" within this file and should be renamed to '_{name}'"
+            for name, line_num in candidates
+        ]
+        return output
+
+
+def _get_repo_root(file_name: str) -> str:
+    """
+    Return the dir to search for usages of a file.
+
+    This is the root of the repository containing the file, or the dir of
+    the file when the repository can't be determined (e.g., the file is in
+    a tmp dir).
+    """
+    try:
+        repo_root = hgit.find_git_root(file_name)
+    except Exception as ex:  # pylint: disable=broad-except
+        _LOG.debug("Could not find the git root of '%s': %s", file_name, ex)
+        repo_root = os.path.dirname(os.path.abspath(file_name))
+    return repo_root
+
+
+# #############################################################################
+# Fix mode
+# #############################################################################
+
+
+def _get_rename_edits(
+    file_name: str, name: str
+) -> List[Tuple[int, int, int, str]]:
+    """
+    Get the position-exact edits to rename a function within its file.
+
+    :return: list of (line number, start col, end col, new text) edits
+    """
+    new_name = "_" + name
+    source = hio.from_file(file_name)
+    tree = ast.parse(source)
+    lines = source.split("\n")
+    edits = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name != name:
+                continue
+            line = lines[node.lineno - 1]
+            m = re.search(r"\bdef\s+", line)
+            hdbg.dassert(
+                m is not None,
+                "Can't find 'def' for '%s' in line '%s'",
+                name,
+                line,
+            )
+            start = m.end()  # type: ignore[union-attr]
+            hdbg.dassert(
+                line.startswith(name, start),
+                "Expected '%s' right after 'def' in line '%s'",
+                name,
+                line,
+            )
+            edits.append((node.lineno, start, start + len(name), new_name))
+        elif isinstance(node, ast.Name):
+            if node.id == name:
+                edits.append(
+                    (
+                        node.lineno,
+                        node.col_offset,
+                        node.col_offset + len(name),
+                        new_name,
+                    )
+                )
+        elif isinstance(node, ast.Attribute):
+            if node.attr == name:
+                end_lineno = node.end_lineno
+                end_col = node.end_col_offset
+                hdbg.dassert(end_lineno is not None)
+                hdbg.dassert(end_col is not None)
+                # The attribute name is at the end of the node.
+                edits.append(
+                    (
+                        end_lineno,  # type: ignore[arg-type]
+                        end_col - len(name),  # type: ignore[operator]
+                        end_col,
+                        new_name,
+                    )
+                )
+    # Ensure that there are no overlapping edits.
+    by_line: Dict[int, List[Tuple[int, int, int, str]]] = {}
+    for edit in edits:
+        by_line.setdefault(edit[0], []).append(edit)
+    for line_edits in by_line.values():
+        line_edits.sort(key=lambda e: e[1])
+        for prev, cur in zip(line_edits, line_edits[1:]):
+            hdbg.dassert_lte(prev[2], cur[1])
+    return edits
+
+
+def _fix_file(file_name: str, search_dirs: List[str]) -> List[str]:
+    """
+    Rename the flagged public functions of a file to make them private.
+
+    The functions and their usages within the defining file are renamed;
+    the files other than the defining file are never touched.
+
+    :param search_dirs: dirs to search for usages
+    :return: list of messages describing the renames
+    """
+    file_name = os.path.abspath(file_name)
+    usages: _UsageMap = {}
+    for search_dir in search_dirs:
+        cur_usages = _collect_usages(search_dir)
+        for name, locs in cur_usages.items():
+            file_usages = usages.setdefault(name, {})
+            for loc_file, positions in locs.items():
+                file_usages.setdefault(loc_file, []).extend(positions)
+    candidates = _find_private_function_candidates(file_name, usages)
+    all_edits = []
+    for name, line_num in candidates:
+        all_edits.extend(_get_rename_edits(file_name, name))
+        _LOG.debug("Renaming function '%s' in '%s'", name, file_name)
+    if all_edits:
+        lines = hio.from_file(file_name).split("\n")
+        # Apply the edits bottom-up so that the positions stay valid.
+        for line_num, start, end, new_text in sorted(all_edits, reverse=True):
+            line = lines[line_num - 1]
+            lines[line_num - 1] = line[:start] + new_text + line[end:]
+        source = "\n".join(lines)
+        # Verify that the file is still valid Python code.
+        ast.parse(source)
+        hio.to_file(file_name, source)
+    output = [
+        f"{file_name}:{line_num}: renamed '{name}' to '_{name}'"
+        for name, line_num in candidates
+    ]
+    return output
+
+
+# #############################################################################
+# Command line
+# #############################################################################
+
+
+def _parse() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=hparser.CustomHelpFormatter,
+    )
+    parser.add_argument(
+        "files",
+        nargs="+",
+        action="store",
+        type=str,
+        help="Files to process",
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Rename the flagged functions to make them private",
+    )
+    parser.add_argument(
+        "--search_dirs",
+        action="store",
+        type=str,
+        default=None,
+        help="Comma-separated list of dirs to search for usages; by default"
+        " only the repo of the linted file is searched",
+    )
+    hparser.add_verbosity_arg(parser)
+    return parser
+
+
+def _main(parser: argparse.ArgumentParser) -> None:
+    args = parser.parse_args()
+    hdbg.init_logger(verbosity=args.log_level)
+    search_dirs: Optional[List[str]] = None
+    if args.search_dirs is not None:
+        search_dirs = args.search_dirs.split(",")
+    if args.fix:
+        if search_dirs is None:
+            # Without explicit search dirs, search the dir of each file.
+            search_dirs = []
+            for file_name in args.files:
+                file_dir = os.path.dirname(os.path.abspath(file_name))
+                if file_dir not in search_dirs:
+                    search_dirs.append(file_dir)
+        for file_name in args.files:
+            msgs = _fix_file(file_name, search_dirs)
+            print("\n".join(msgs))
+    else:
+        action = _CheckPrivateFunctions(search_dirs=search_dirs)
+        action.run(args.files)
+
+
+if __name__ == "__main__":
+    _main(_parse())

--- a/linters/base.py
+++ b/linters/base.py
@@ -38,6 +38,7 @@ import linters.amp_check_import as lamchimp
 import linters.amp_check_md_reference as lachmdre
 import linters.amp_check_md_toc_headers as lacmtohe
 import linters.amp_check_merge_conflict as lachmeco
+import linters.amp_check_private_functions as lamchprfu
 import linters.amp_class_method_order as laclmeor
 import linters.amp_doc_formatter as lamdofor
 import linters.amp_fix_md_links as lafimdli
@@ -188,6 +189,12 @@ _NON_MODIFYING_ACTIONS: List[Tuple[str, str, Type[liaction.Action]]] = [
         "check_md_reference",
         "Checks README.md for reference to the current markdown file",
         lachmdre._ReadmeLinter,  # pylint: disable=protected-access
+    ),
+    (
+        "check_private_functions",
+        "Finds public functions that are only used within their defining"
+        " file",
+        lamchprfu._CheckPrivateFunctions,  # pylint: disable=protected-access
     ),
     (
         "flake8",

--- a/linters/test/test_amp_check_private_functions.py
+++ b/linters/test/test_amp_check_private_functions.py
@@ -1,0 +1,283 @@
+import logging
+import os
+from typing import Dict, List, Tuple
+
+import helpers.hio as hio
+import helpers.hunit_test as hunitest
+import linters.amp_check_private_functions as lamchprfu
+
+_LOG = logging.getLogger(__name__)
+
+
+class Test_find_private_function_candidates(hunitest.TestCase):
+    """
+    Test finding the functions that should be private.
+    """
+
+    def helper(
+        self,
+        files: Dict[str, str],
+        file_name: str,
+        expected: List[Tuple[str, int]],
+    ) -> None:
+        """
+        Create the input files, run the check and compare the outcome.
+
+        :param files: contents by file name
+        :param file_name: the file to check
+        :param expected: expected (function name, line number) pairs
+        """
+        in_dir = self.get_input_dir()
+        hio.create_dir(in_dir, incremental=True)
+        for cur_file_name, content in files.items():
+            hio.to_file(os.path.join(in_dir, cur_file_name), content)
+        file_path = os.path.join(in_dir, file_name)
+        usages = lamchprfu._collect_usages(in_dir)
+        actual = lamchprfu._find_private_function_candidates(file_path, usages)
+        self.assertEqual(actual, expected)
+
+    def test1(self) -> None:
+        """
+        Test a function that is used only within its file and a function
+        that is not used anywhere.
+        """
+        files = {
+            "a.py": "\n".join(
+                [
+                    "def foo() -> int:",
+                    "    return 1",
+                    "",
+                    "",
+                    "def bar() -> int:",
+                    "    return foo() + 1",
+                ]
+            ),
+        }
+        # `bar` is not used anywhere, so it is a candidate as well.
+        expected = [("foo", 1), ("bar", 5)]
+        self.helper(files, "a.py", expected)
+
+    def test2(self) -> None:
+        """
+        Test a function that is also used in another file.
+        """
+        files = {
+            "a.py": "\n".join(["def foo():", "    return 1"]),
+            "b.py": "\n".join(["import a", "", "x = a.foo()"]),
+        }
+        expected = []
+        self.helper(files, "a.py", expected)
+
+    def test3(self) -> None:
+        """
+        Test that private, `main` and dunder functions are skipped.
+        """
+        files = {
+            "a.py": "\n".join(
+                [
+                    "def _private() -> None:",
+                    "    pass",
+                    "",
+                    "",
+                    "def main() -> None:",
+                    "    pass",
+                    "",
+                    "",
+                    "def __dunder__() -> None:",
+                    "    pass",
+                ]
+            ),
+        }
+        expected = []
+        self.helper(files, "a.py", expected)
+
+    def test4(self) -> None:
+        """
+        Test a function that is not used anywhere.
+        """
+        files = {"a.py": "\n".join(["def unused():", "    pass"])}
+        expected = [("unused", 1)]
+        self.helper(files, "a.py", expected)
+
+    def test5(self) -> None:
+        """
+        Test that an unrelated identifier with the same name in another
+        file keeps the function public.
+        """
+        files = {
+            "a.py": "\n".join(["def foo():", "    pass"]),
+            "b.py": "\n".join(["foo = 3", "print(foo)"]),
+        }
+        expected = []
+        self.helper(files, "a.py", expected)
+
+    def test6(self) -> None:
+        """
+        Test that a function invoked dynamically through a decorator is
+        skipped.
+        """
+        files = {
+            "a.py": "\n".join(
+                [
+                    "from invoke import task",
+                    "",
+                    "",
+                    "@task",
+                    "def run_something(ctx):",
+                    "    pass",
+                ]
+            ),
+        }
+        expected = []
+        self.helper(files, "a.py", expected)
+
+    def test7(self) -> None:
+        """
+        Test that a function exported through `__all__` is skipped.
+        """
+        files = {
+            "a.py": "\n".join(
+                [
+                    '__all__ = ["foo"]',
+                    "",
+                    "",
+                    "def foo():",
+                    "    pass",
+                ]
+            ),
+        }
+        expected = []
+        self.helper(files, "a.py", expected)
+
+    def test8(self) -> None:
+        """
+        Test that class methods are not considered.
+        """
+        files = {
+            "a.py": "\n".join(
+                [
+                    "class Dummy:",
+                    "    def method(self):",
+                    "        return 1",
+                ]
+            ),
+        }
+        expected = []
+        self.helper(files, "a.py", expected)
+
+
+class Test_CheckPrivateFunctions(hunitest.TestCase):
+    """
+    Test the linter action end-to-end.
+    """
+
+    def test1(self) -> None:
+        """
+        Test running the action on a file.
+        """
+        in_dir = self.get_input_dir()
+        hio.create_dir(in_dir, incremental=True)
+        file_name = os.path.join(in_dir, "a.py")
+        content = "\n".join(
+            [
+                "def foo():",
+                "    return 1",
+                "",
+                "",
+                "def bar():",
+                "    return foo()",
+            ]
+        )
+        hio.to_file(file_name, content)
+        action = lamchprfu._CheckPrivateFunctions(search_dirs=[in_dir])
+        actual = action.execute(file_name, pedantic=0)
+        file_path = os.path.abspath(file_name)
+        # `bar` is not used anywhere, so it is a candidate as well.
+        expected = [
+            f"{file_path}:1: the function 'foo' is only used within this"
+            " file and should be renamed to '_foo'",
+            f"{file_path}:5: the function 'bar' is only used within this"
+            " file and should be renamed to '_bar'",
+        ]
+        self.assertEqual(actual, expected)
+
+
+class Test_fix_file(hunitest.TestCase):
+    """
+    Test the fix mode.
+    """
+
+    def test1(self) -> None:
+        """
+        Test renaming a function and its usages within the defining file.
+        """
+        in_dir = self.get_input_dir()
+        hio.create_dir(in_dir, incremental=True)
+        a_py = os.path.join(in_dir, "a.py")
+        b_py = os.path.join(in_dir, "b.py")
+        hio.to_file(
+            a_py,
+            "\n".join(
+                [
+                    "def foo():",
+                    "    return 1",
+                    "",
+                    "",
+                    "def bar():",
+                    "    return foo()",
+                ]
+            ),
+        )
+        hio.to_file(b_py, "x = 3\n")
+        msgs = lamchprfu._fix_file(a_py, [in_dir])
+        # The functions and their usages in `a.py` are renamed.
+        expected_content = "\n".join(
+            [
+                "def _foo():",
+                "    return 1",
+                "",
+                "",
+                "def _bar():",
+                "    return _foo()",
+            ]
+        )
+        self.assertEqual(hio.from_file(a_py), expected_content)
+        # The other file is not touched.
+        self.assertEqual(hio.from_file(b_py), "x = 3\n")
+        file_path = os.path.abspath(a_py)
+        expected_msgs = [
+            f"{file_path}:1: renamed 'foo' to '_foo'",
+            f"{file_path}:5: renamed 'bar' to '_bar'",
+        ]
+        self.assertEqual(msgs, expected_msgs)
+
+
+class Test_get_rename_edits(hunitest.TestCase):
+    """
+    Test getting the position-exact rename edits.
+    """
+
+    def test1(self) -> None:
+        """
+        Test the edits for a def, a plain name and an attribute.
+        """
+        in_dir = self.get_input_dir()
+        hio.create_dir(in_dir, incremental=True)
+        file_name = os.path.join(in_dir, "a.py")
+        lines = [
+            "def foo():",
+            "    return 1",
+            "",
+            "",
+            "holder = None",
+            "holder.foo = foo",
+        ]
+        hio.to_file(file_name, "\n".join(lines))
+        actual = lamchprfu._get_rename_edits(file_name, "foo")
+        # The def is at line 1; the attribute and the name are at line 6.
+        expected = [
+            (1, 4, 7, "_foo"),
+            (6, 7, 10, "_foo"),
+            (6, 13, 16, "_foo"),
+        ]
+        self.assertEqual(sorted(actual), expected)


### PR DESCRIPTION
Implements #1374 ($100 bounty task "Write a script to find private functions" from the public bounty sheet).

Disclosed AI assistance: developed with AI coding assistance under the supervision of the account owner.

## Problem

Public module-level functions (names not starting with `_`) that are never referenced outside their defining file should be private, per the bounty spec. The repo had no automated way to detect them.

## Solution

New non-modifying linter action `check_private_functions` (`linters/amp_check_private_functions.py`), registered in `_NON_MODIFYING_ACTIONS` before `flake8`:

- Collects the public module-level functions of each linted `.py` file via `ast`, skipping `_`-prefixed names, dunders, `main`, `__init__.py`, test code, `@task`-decorated functions (called dynamically by `invoke`), and names exported in `__all__`.
- Builds a repo-wide map of identifier usages (`ast.Name` + `ast.Attribute`), parsed once per run.
- Flags a function only when every usage of its name is inside its defining file; functions with no usage anywhere are flagged too (they should be private or removed). Any same-name identifier in another file counts as a usage, so the check prefers false negatives over false positives.
- Lint output: `<file>:<line>: the function 'foo' is only used within this file and should be renamed to '_foo'`.
- `--fix` switch renames flagged functions and their usages within the defining file using exact AST node positions (def sites, `Name` and `Attribute` nodes), so strings/comments are never touched, and re-verifies the file parses afterwards.
- `--search_dirs` allows scanning additional repos, since `helpers` is consumed by other repos: a function used only by another repo is reported by default and should then stay public.

## Verification

- 11 new unit tests in `linters/test/test_amp_check_private_functions.py` (detection, end-to-end action, fix mode, rename edits) all pass.
  Environment note: I don't have the project Docker image locally, so the tests were run in WSL Ubuntu (Python 3.14, pytest 8.4.2) with the repo `conftest.py` active. The test file and linter only use stdlib + existing repo helpers.
- `black --line-length 82 --check` clean on both new files; `flake8 --max-line-length=82 --extend-ignore=E203,W503` clean.
- Trial runs on real repo files: no false positives on `helpers/hstring.py` (all public functions are used externally — independently cross-checked), and renames via `--fix` were applied and verified on a scratch copy.
- Known limitation (documented in the module docstring): usages are found statically, so dynamic references (strings, `getattr`) can cause false negatives; usages are searched within the repo of the linted file by default.

Happy to adjust scope (e.g., also consider module-level constants or class methods, or a pedantic mode).
