### PR TITLE
HelpersTask1380_Add_pytest_run_class

### DIFF
--- a/docs/tools/all.invoke_workflows.how_to_guide.md
+++ b/docs/tools/all.invoke_workflows.how_to_guide.md
@@ -394,6 +394,30 @@ TODO(gp): Describe
 
 #### Run Only One Test Based on Its Name
 
+- To resolve an exact class name and run it in the current Python environment:
+
+  ```bash
+  > invoke pytest_run_class -c Test_obj_to_str1
+  ```
+
+  This runs `pytest path/to/test_file.py::Test_obj_to_str1` instead of collecting
+  the entire repository with `pytest -k`. Run it inside the development container
+  when the selected test needs container dependencies.
+
+- To inspect the command first, or run the entire file containing the class:
+
+  ```bash
+  > invoke pytest_run_class -c Test_obj_to_str1 --preview
+  > invoke pytest_run_class -c Test_obj_to_str1 --test-file
+  > invoke pytest_run_class -c Test_obj_to_str1 --dir-name helpers --preview
+  ```
+
+  The search reuses `find_test_class` conventions: `test_*.py` files under `test`
+  directories and class declarations recognized by that finder. Matching is
+  exact; a missing class or multiple matches causes an error without running
+  pytest. Use `--dir-name` to disambiguate classes. Preview does not run pytest
+  or copy to the clipboard. Normal execution preserves pytest's exit status.
+
 - Outside the `dev` container
 
   ```bash

--- a/helpers/lib_tasks/lib_tasks_pytest.py
+++ b/helpers/lib_tasks/lib_tasks_pytest.py
@@ -8,9 +8,11 @@ import json
 import logging
 import os
 import re
+import shlex
 import sys
 from typing import Any, List, Optional, Tuple
 
+from invoke.exceptions import Exit
 from invoke.tasks import task
 
 # We want to minimize the dependencies from non-standard Python packages since
@@ -27,6 +29,7 @@ import helpers.hserver as hserver
 import helpers.hsystem as hsystem
 import helpers.htraceback as htraceb
 import helpers.lib_tasks.lib_tasks_docker as hltltado
+import helpers.lib_tasks.lib_tasks_find as hltltafi
 import helpers.lib_tasks.lib_tasks_lint as hltltali
 import helpers.lib_tasks.lib_tasks_utils as hltltaut
 import helpers.repo_config_utils as hrecouti
@@ -1118,6 +1121,73 @@ def traceback(  # type: ignore
     cmd.append("--open_vim")
     cmd = " ".join(cmd)
     hltltaut.run(ctx, cmd, pty=True)
+
+
+# #############################################################################
+# pytest_run_class
+# #############################################################################
+
+
+def _get_pytest_run_class_cmd(
+    class_name: str, dir_name: str, *, test_file: bool
+) -> str:
+    """
+    Resolve one exact test class without collecting or importing tests.
+
+    :param class_name: class name accepted by the existing test finder
+    :param dir_name: directory containing the project's `test` directories
+    :param test_file: run the containing file instead of just the class
+    :return: shell command with exactly one quoted pytest collection argument
+    """
+    hdbg.dassert_ne(class_name.strip(), "", "Specify a test class name")
+    file_names = hltltafi._find_test_files(dir_name)
+    matches = hltltafi._find_test_class(class_name, file_names, exact_match=True)
+    # Never let an empty or ambiguous selection fall back to the full suite.
+    hdbg.dassert_eq(
+        len(matches),
+        1,
+        "Expected one exact match for '%s' in '%s'; found %s. "
+        "Use --dir-name to narrow the search.",
+        class_name,
+        dir_name,
+        matches,
+    )
+    node_id = matches[0]
+    if test_file:
+        node_id = node_id.rsplit("::", 1)[0]
+    cmd = [
+        "pytest",
+        shlex.quote(node_id),
+    ]
+    cmd = " ".join(cmd)
+    return cmd
+
+
+@task
+def pytest_run_class(
+    ctx, class_name, dir_name=".", test_file=False, preview=False
+):  # type: ignore
+    """
+    Run one test class without collecting the entire repository.
+
+    Examples:
+    - `invoke pytest_run_class -c TestExample --preview`
+    - `invoke pytest_run_class -c TestExample --dir-name helpers --test-file`
+
+    :param class_name: exact class name, as used by `find_test_class`
+    :param dir_name: narrow the search to this directory (default: .)
+    :param test_file: run all tests in the file containing the class
+    :param preview: print the command without running pytest
+    """
+    hltltaut.report_task()
+    _ = ctx
+    cmd = _get_pytest_run_class_cmd(class_name, dir_name, test_file=test_file)
+    if preview:
+        print(cmd)
+    else:
+        rc = hsystem.system(cmd, abort_on_error=False, suppress_output=False)
+        if rc:
+            raise Exit(code=rc)
 
 
 # #############################################################################

--- a/helpers/lib_tasks/test/test_lib_tasks_pytest_run_class.py
+++ b/helpers/lib_tasks/test/test_lib_tasks_pytest_run_class.py
@@ -1,0 +1,195 @@
+import contextlib
+import io
+import os
+import shlex
+import unittest.mock as umock
+from typing import Tuple
+
+import invoke
+import pytest
+
+import helpers.hio as hio
+import helpers.hprint as hprint
+import helpers.hunit_test as hunitest
+import helpers.lib_tasks.lib_tasks_pytest as hltltapy
+
+# pylint: disable=protected-access
+
+
+# #############################################################################
+# Test_pytest_run_class
+# #############################################################################
+
+
+@pytest.mark.slow
+class Test_pytest_run_class(hunitest.TestCase):
+    """
+    Exercise the real finder and pytest, without collecting unrelated modules.
+    """
+
+    def _prepare(self, *, fail: bool = False) -> Tuple[str, str, str]:
+        """
+        Create a test suite under a path requiring shell quoting.
+        """
+        root = os.path.join(self.get_scratch_space(), "suite space' $value")
+        test_dir = os.path.join(root, "test")
+        os.makedirs(test_dir)
+        marker = os.path.join(root, "executed.txt")
+        target = os.path.join(test_dir, "test_selected.py")
+        source = f"""
+        class TestSelected(object):
+            def test_selected(self):
+                with open({marker!r}, "a") as stream:
+                    stream.write("selected;")
+                assert {not fail!r}
+
+        class TestSelectedExtra(object):
+            def test_extra(self):
+                with open({marker!r}, "a") as stream:
+                    stream.write("extra;")
+        """
+        hio.to_file(target, hprint.dedent(source))
+        # Collecting this unrelated module must fail, even before tests run.
+        unrelated = os.path.join(test_dir, "test_unrelated.py")
+        hio.to_file(unrelated, 'raise RuntimeError("Unrelated collection")')
+        hio.to_file(os.path.join(root, "pytest.ini"), "[pytest]")
+        return root, marker, target
+
+    def _run(
+        self,
+        root: str,
+        *,
+        class_name: str = "TestSelected",
+        test_file: bool = False,
+        preview: bool = False,
+    ) -> str:
+        """
+        Run with an isolated pytest configuration and capture task stdout.
+        """
+        config = os.path.join(root, "pytest.ini")
+        pytest_opts = (
+            f"-q -c {shlex.quote(config)} --confcutdir {shlex.quote(root)}"
+        )
+        env = {
+            "PYTEST_ADDOPTS": pytest_opts,
+            "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+            "SKIP_VERSION_CHECK": "1",
+        }
+        output = io.StringIO()
+        with (
+            umock.patch.dict(os.environ, env),
+            contextlib.redirect_stdout(output),
+        ):
+            hltltapy.pytest_run_class.body(
+                None,
+                class_name,
+                dir_name=root,
+                test_file=test_file,
+                preview=preview,
+            )
+        return output.getvalue()
+
+    def test1(self) -> None:
+        """
+        Run only the exact class, with no import of an unrelated test module.
+        """
+        root, marker, _ = self._prepare()
+        self._run(root)
+        actual = hio.from_file(marker)
+        expected = "selected;"
+        self.assert_equal(actual, expected)
+
+    def test2(self) -> None:
+        """
+        File mode runs both classes in the selected file and no other file.
+        """
+        root, marker, _ = self._prepare()
+        self._run(root, test_file=True)
+        actual = hio.from_file(marker)
+        expected = "selected;extra;"
+        self.assert_equal(actual, expected)
+
+    def test3(self) -> None:
+        """
+        Preview prints a reusable command and does not run the selected test.
+        """
+        root, marker, target = self._prepare()
+        output = self._run(root, preview=True)
+        actual = shlex.split(output.splitlines()[-1])
+        expected = ["pytest", f"{target}::TestSelected"]
+        self.assertEqual(actual, expected)
+        self.assertFalse(os.path.exists(marker))
+
+    def test4(self) -> None:
+        """
+        Preview of file mode contains exactly the selected file argument.
+        """
+        root, marker, target = self._prepare()
+        output = self._run(root, test_file=True, preview=True)
+        actual = shlex.split(output.splitlines()[-1])
+        expected = ["pytest", target]
+        self.assertEqual(actual, expected)
+        self.assertFalse(os.path.exists(marker))
+
+    def test5(self) -> None:
+        """
+        A partial class name must not run any tests.
+        """
+        root, marker, _ = self._prepare()
+        class_name = "TestSelect"
+        with self.assertRaises(AssertionError):
+            self._run(root, class_name=class_name)
+        self.assertFalse(os.path.exists(marker))
+
+    def test6(self) -> None:
+        """
+        Ambiguous classes fail before execution, including in file mode.
+        """
+        root, marker, _ = self._prepare()
+        duplicate = os.path.join(root, "test", "test_duplicate.py")
+        source = """
+        class TestSelected(object):
+            pass
+        """
+        hio.to_file(duplicate, hprint.dedent(source))
+        for test_file in (False, True):
+            with self.assertRaises(AssertionError):
+                self._run(root, test_file=test_file)
+        self.assertFalse(os.path.exists(marker))
+
+    def test7(self) -> None:
+        """
+        Empty and whitespace-only names cannot launch the full suite.
+        """
+        root, marker, _ = self._prepare()
+        for class_name in ("", "   "):
+            with self.assertRaises(AssertionError):
+                self._run(root, class_name=class_name)
+        self.assertFalse(os.path.exists(marker))
+
+    def test8(self) -> None:
+        """
+        Preserve pytest's failure exit status instead of reporting success.
+        """
+        root, marker, _ = self._prepare(fail=True)
+        with self.assertRaises(invoke.exceptions.Exit) as cm:
+            self._run(root)
+        self.assertEqual(cm.exception.code, 1)
+        actual = hio.from_file(marker)
+        expected = "selected;"
+        self.assert_equal(actual, expected)
+
+    def test9(self) -> None:
+        """
+        Preserve pytest's no-tests-collected exit status as well.
+        """
+        root, marker, target = self._prepare()
+        source = """
+        class TestSelected(object):
+            pass
+        """
+        hio.to_file(target, hprint.dedent(source))
+        with self.assertRaises(invoke.exceptions.Exit) as cm:
+            self._run(root)
+        self.assertEqual(cm.exception.code, 5)
+        self.assertFalse(os.path.exists(marker))

--- a/tasks.py
+++ b/tasks.py
@@ -120,6 +120,7 @@ from helpers.lib_tasks import (  # isort: skip # noqa: F401  # pylint: disable=u
     pytest_find_unused_goldens,
     pytest_rename_test,
     pytest_repro,
+    pytest_run_class,
     run_blank_tests,
     run_coverage_report,
     run_coverage,


### PR DESCRIPTION
`pytest -k ClassName` collects unrelated modules before selecting tests. This adds `invoke pytest_run_class -c ClassName`, which reuses the existing finder to resolve exactly one class and runs pytest on its node ID. `--test-file` selects the containing file, `--preview` prints the command without executing it, and `--dir-name` narrows the search. Missing or ambiguous names fail before execution; shell quoting and pytest exit codes are preserved.

Related proposal: #1380. The existing finder's source-format and `test` directory conventions are retained and documented. This change includes the root task export, usage examples, and nine behavior tests using real pytest subprocesses, including an unrelated module that raises during import.

## Validation

[Linux validation run](https://github.com/LvJinze25041017/causify-helpers-bounty/actions/runs/34375913264) on Ubuntu / Python 3.11:

- **48 passed, 2 skipped**, including all nine new tests. The two existing skips require the `amp` repository.
- Ran `python -m pytest helpers/lib_tasks/test/test_lib_tasks_pytest_run_class.py helpers/lib_tasks/test/test_lib_tasks_find.py helpers/lib_tasks/test/test_lib_tasks_pytest.py`.
- Verified the actual Invoke help and preview entry point, Python compilation, Ruff E4/E7/E9/F checks, and Ruff formatting of the implementation and new test module.
- The validation branch adds only its workflow on top of this PR's feature commit; temporary workflows and logs are not part of this PR.

[Repository linter attempt](https://github.com/LvJinze25041017/causify-helpers-bounty/actions/runs/34376224071): `python -m invoke lint --files="helpers/lib_tasks/lib_tasks_pytest.py helpers/lib_tasks/test/test_lib_tasks_pytest_run_class.py tasks.py docs/tools/all.invoke_workflows.how_to_guide.md"` stops before linting because `docker pull ghcr.io/causify-ai/helpers:prod` returns `unauthorized`. The official container linter and full container regressions therefore remain unverified; the focused run above is not claimed as full repository validation.

The upstream Fast tests, Slow tests, Gitleaks Scan, and Claude Code Review workflows currently report `action_required`; they have not produced passing test results. Maintainer approval is needed to run the fork contribution workflows. GitHub reports this branch as mergeable (no conflicts), but merging is blocked by outstanding requirements. Self-assignment returned HTTP 403 and requesting a reviewer returned HTTP 404, so those fields are left unchecked rather than claimed complete.

## Contribution Status

AI-assisted contribution prepared, reviewed against repository conventions, and tested by Codex for @LvJinze25041017. No independent human review is claimed. Local implementation preceded the public proposal. Contributor vetting and a paid bounty slot are unconfirmed, including in light of existing proposals #1356 and #1359; this submission does not assert assignment, acceptance, or entitlement to payment.

## First Review Checklist

- [x] Branch uses the related issue tag and normalized task title.
- [x] Commit message is informative and identifies the related task.
- [x] PR title matches the branch name.
- [x] Starting post describes the change and mentions the related issue.
- [x] No closing issue link was created (`closingIssuesReferences.totalCount = 0`).
- [ ] At least one reviewer is assigned.
- [ ] PR author is listed under Assignees.
- [ ] All GitHub Actions checks pass (focused validation passed; container linter blocked as above; upstream checks pending).
- [x] Branch includes current master `f1704df8bf1c18efa99a9ee0d80a704d86d0eaca`.
- [x] No conflicts with master (GitHub reports `mergeable: true`).
- [x] No temporary files or logs are included.
- [ ] All changed files have passed the repository Linter (blocked by image access).
- [x] No included file exceeds 500 KB.
- [x] Errors are reported as text, without screenshots.
- [ ] `PR_for_reviewers` label is present if review is requested.
- [ ] Review fixes applied everywhere (no review received yet).
- [ ] Review conversations resolved (no review received yet).
- [ ] Review re-requested after resolving comments (no review received yet).
