### PR TITLE
Add pytest_run_class invoke task

### DIFF
--- a/helpers/lib_tasks/__init__.py
+++ b/helpers/lib_tasks/__init__.py
@@ -23,6 +23,7 @@ from .lib_tasks_lint import *  # isort:skip  # noqa: F401,F403 # pylint: disable
 from .lib_tasks_perms import *  # isort:skip  # noqa: F401,F403 # pylint: disable=unused-import,unused-wildcard-import,wildcard-import
 from .lib_tasks_print import *  # isort:skip  # noqa: F401,F403 # pylint: disable=unused-import,unused-wildcard-import,wildcard-import
 from .lib_tasks_pytest import *  # isort:skip  # noqa: F401,F403 # pylint: disable=unused-import,unused-wildcard-import,wildcard-import
+from .lib_tasks_pytest_run_class import *  # isort:skip  # noqa: F401,F403 # pylint: disable=unused-import,unused-wildcard-import,wildcard-import
 from .lib_tasks_utils import *  # isort:skip  # noqa: F401,F403 # pylint: disable=unused-import,unused-wildcard-import,wildcard-import
 
 _LOG = logging.getLogger(__name__)

--- a/helpers/lib_tasks/lib_tasks_pytest_run_class.py
+++ b/helpers/lib_tasks/lib_tasks_pytest_run_class.py
@@ -1,0 +1,80 @@
+"""
+Import as:
+
+import helpers.lib_tasks.lib_tasks_pytest_run_class as hltltaprc
+"""
+
+import logging
+
+from invoke.tasks import task
+
+import helpers.lib_tasks.lib_tasks_find as hltltafi
+import helpers.lib_tasks.lib_tasks_pytest as hltltapy
+import helpers.lib_tasks.lib_tasks_utils as hltltaut
+
+_LOG = logging.getLogger(__name__)
+
+# pylint: disable=protected-access
+
+
+def _resolve_pytest_class_target(class_name: str, dir_name: str) -> str:
+    """Resolve one exact test class to a pytest node id."""
+    if not class_name:
+        raise ValueError("You need to specify a class name")
+    file_names = hltltafi._find_test_files(dir_name)
+    matches = hltltafi._find_test_class(
+        class_name, file_names, exact_match=True
+    )
+    if not matches:
+        raise ValueError(
+            f"Could not find test class '{class_name}' under '{dir_name}'"
+        )
+    if len(matches) != 1:
+        raise ValueError(
+            f"Test class '{class_name}' is ambiguous: {matches}"
+        )
+    return matches[0]
+
+
+def _build_pytest_run_class_command(class_name: str, dir_name: str = ".") -> str:
+    """Build a pytest command targeting exactly one test class."""
+    target = _resolve_pytest_class_target(class_name, dir_name)
+    return f"pytest {target}"
+
+
+@task
+def pytest_run_class(  # type: ignore
+    ctx,
+    class_name,
+    dir_name=".",
+    dry_run=False,
+    stage="dev",
+    version="",
+    skip_pull=False,
+):
+    """Run exactly one pytest class resolved by its class name.
+
+    :param class_name: exact test class name to execute
+    :param dir_name: directory to search for the class
+    :param dry_run: print the resolved pytest command without executing it
+    :param stage: select a specific stage for the Docker image
+    :param version: Docker image version
+    :param skip_pull: skip pulling the Docker image before execution
+    """
+    hltltaut.report_task()
+    cmd = _build_pytest_run_class_command(class_name, dir_name)
+    _LOG.info("cmd=%s", cmd)
+    if dry_run:
+        print(cmd)
+        return 0
+    rc = hltltapy._run_test_cmd(
+        ctx,
+        stage,
+        version,
+        cmd,
+        coverage=False,
+        collect_only=False,
+        skip_pull=skip_pull,
+        start_coverage_script=False,
+    )
+    return rc

--- a/helpers/lib_tasks/test/test_lib_tasks_pytest_run_class.py
+++ b/helpers/lib_tasks/test/test_lib_tasks_pytest_run_class.py
@@ -1,0 +1,123 @@
+import unittest.mock as umock
+
+import pytest
+
+import helpers.lib_tasks.lib_tasks_pytest_run_class as hltltaprc
+import helpers.hunit_test as hunitest
+
+# pylint: disable=protected-access
+
+
+class Test_resolve_pytest_class_target1(hunitest.TestCase):
+    def test_success1(self) -> None:
+        file_names = ["helpers/foo/test/test_bar.py"]
+        matches = ["helpers/foo/test/test_bar.py::TestBar"]
+        with (
+            umock.patch.object(
+                hltltaprc.hltltafi,
+                "_find_test_files",
+                return_value=file_names,
+            ) as find_files,
+            umock.patch.object(
+                hltltaprc.hltltafi,
+                "_find_test_class",
+                return_value=matches,
+            ) as find_class,
+        ):
+            actual = hltltaprc._resolve_pytest_class_target("TestBar", ".")
+        self.assert_equal(actual, matches[0])
+        find_files.assert_called_once_with(".")
+        find_class.assert_called_once_with(
+            "TestBar", file_names, exact_match=True
+        )
+
+    def test_missing1(self) -> None:
+        with (
+            umock.patch.object(
+                hltltaprc.hltltafi,
+                "_find_test_files",
+                return_value=["helpers/foo/test/test_bar.py"],
+            ),
+            umock.patch.object(
+                hltltaprc.hltltafi, "_find_test_class", return_value=[]
+            ),
+            pytest.raises(ValueError, match="Could not find test class"),
+        ):
+            hltltaprc._resolve_pytest_class_target("TestMissing", ".")
+
+    def test_ambiguous1(self) -> None:
+        matches = [
+            "helpers/a/test/test_a.py::TestSame",
+            "helpers/b/test/test_b.py::TestSame",
+        ]
+        with (
+            umock.patch.object(
+                hltltaprc.hltltafi,
+                "_find_test_files",
+                return_value=["a", "b"],
+            ),
+            umock.patch.object(
+                hltltaprc.hltltafi, "_find_test_class", return_value=matches
+            ),
+            pytest.raises(ValueError, match="ambiguous"),
+        ):
+            hltltaprc._resolve_pytest_class_target("TestSame", ".")
+
+
+class Test_pytest_run_class1(hunitest.TestCase):
+    def test_build_command1(self) -> None:
+        target = "helpers/foo/test/test_bar.py::TestBar"
+        with umock.patch.object(
+            hltltaprc,
+            "_resolve_pytest_class_target",
+            return_value=target,
+        ):
+            actual = hltltaprc._build_pytest_run_class_command("TestBar")
+        self.assert_equal(actual, f"pytest {target}")
+
+    def test_dry_run1(self) -> None:
+        ctx = umock.Mock()
+        with (
+            umock.patch.object(
+                hltltaprc,
+                "_build_pytest_run_class_command",
+                return_value="pytest path/test_x.py::TestX",
+            ),
+            umock.patch.object(hltltaprc.hltltapy, "_run_test_cmd") as run_cmd,
+        ):
+            actual = hltltaprc.pytest_run_class.body(
+                ctx, "TestX", dry_run=True
+            )
+        self.assert_equal(actual, 0)
+        run_cmd.assert_not_called()
+
+    def test_run1(self) -> None:
+        ctx = umock.Mock()
+        with (
+            umock.patch.object(
+                hltltaprc,
+                "_build_pytest_run_class_command",
+                return_value="pytest path/test_x.py::TestX",
+            ),
+            umock.patch.object(
+                hltltaprc.hltltapy, "_run_test_cmd", return_value=7
+            ) as run_cmd,
+        ):
+            actual = hltltaprc.pytest_run_class.body(
+                ctx,
+                "TestX",
+                stage="dev",
+                version="1.2.3",
+                skip_pull=True,
+            )
+        self.assert_equal(actual, 7)
+        run_cmd.assert_called_once_with(
+            ctx,
+            "dev",
+            "1.2.3",
+            "pytest path/test_x.py::TestX",
+            coverage=False,
+            collect_only=False,
+            skip_pull=True,
+            start_coverage_script=False,
+        )

--- a/tasks.py
+++ b/tasks.py
@@ -120,6 +120,7 @@ from helpers.lib_tasks import (  # isort: skip # noqa: F401  # pylint: disable=u
     pytest_find_unused_goldens,
     pytest_rename_test,
     pytest_repro,
+    pytest_run_class,
     run_blank_tests,
     run_coverage_report,
     run_coverage,


### PR DESCRIPTION
## Summary

Implements the $50 `pytest_run_class` bounty plan tracked in #1359.

- Reuses the existing exact class-resolution helpers instead of collecting/running the full suite.
- Adds a root Invoke task that resolves exactly one class to a pytest node id.
- Fails before pytest execution on missing or ambiguous classes, preventing accidental full-suite fallback.
- Supports `--dry-run` to preview the exact pytest command.
- Routes execution through the existing Docker pytest runner and returns its exit status.
- Adds focused unit coverage for resolution, missing/ambiguous targets, dry-run, command construction, and exit-status propagation.

## Existing-solution search

Before implementation I checked the current repository for an existing `pytest_run_class` task and found none. The closest reusable path is `helpers/lib_tasks/lib_tasks_find.py`, whose `_find_test_files()` + `_find_test_class(..., exact_match=True)` already produce pytest-compatible class node ids; this PR intentionally builds on that instead of introducing another collector.

## Validation

The implementation and focused tests are included in the branch. The authorized remote host transport is intermittently timing out, so I could not honestly claim a completed local Docker/lint run before submission; CI is requested for authoritative validation and I will address any resulting failures.

AI-assisted implementation was used, with the changes reviewed before submission.

Refs #1359
