### PR TITLE
feat: add pytest_run_class invoke task

### DIFF
--- a/helpers/lib_tasks/lib_tasks_pytest.py
+++ b/helpers/lib_tasks/lib_tasks_pytest.py
@@ -27,6 +27,7 @@ import helpers.hserver as hserver
 import helpers.hsystem as hsystem
 import helpers.htraceback as htraceb
 import helpers.lib_tasks.lib_tasks_docker as hltltado
+import helpers.lib_tasks.lib_tasks_find as hltafin
 import helpers.lib_tasks.lib_tasks_lint as hltltali
 import helpers.lib_tasks.lib_tasks_utils as hltltaut
 import helpers.repo_config_utils as hrecouti
@@ -1672,3 +1673,44 @@ def pytest_failed(ctx, file_name="tmp.pytest_log.txt"):  # type: ignore
     script_path = "dev_scripts_helpers/testing/pytest_failed.py"
     cmd = f"python {script_path} -i {file_name}"
     hsystem.system(cmd, abort_on_error=False, suppress_output=False)
+
+
+# #############################################################################
+# pytest_run_class
+# #############################################################################
+
+
+@task
+def pytest_run_class(ctx, class_name, dir_name=".", preview=False):  # type: ignore
+    """
+    Run a specific test class by name.
+
+    :param class_name: the test class to run (e.g., "TestCheckString1")
+    :param dir_name: the directory to search from (default: ".")
+    :param preview: if True, print the command without executing
+    """
+    hltltaut.report_task(txt="class_name dir_name preview")
+    hdbg.dassert_ne(class_name, "", "You need to specify a class name")
+    _ = ctx
+    # Find test files.
+    file_names = hltafin._find_test_files(dir_name)
+    # Find the class.
+    matches = hltafin._find_test_class(class_name, file_names, exact_match=True)
+    if not matches:
+        hsystem.system(
+            f"echo 'Error: No test class found matching \"{class_name}\"'",
+            abort_on_error=True,
+        )
+    elif len(matches) > 1:
+        msg = f"Ambiguous class name \"{class_name}\" matches multiple classes:\n"
+        msg += "\n".join(f"  - {m}" for m in matches)
+        hsystem.system(f"echo '{msg}'", abort_on_error=True)
+    else:
+        # Build pytest node ID.
+        node_id = matches[0]
+        cmd = f'invoke docker_cmd --cmd "pytest {node_id} -v"'
+        if preview:
+            _LOG.info("Preview command: %s", cmd)
+            print(cmd)
+        else:
+            hsystem.system(cmd, abort_on_error=False, suppress_output=False)

--- a/helpers/test/test_lib_tasks_pytest.py
+++ b/helpers/test/test_lib_tasks_pytest.py
@@ -1,0 +1,87 @@
+"""
+Import as:
+
+import helpers.test.test_lib_tasks_pytest as hltltapyt
+"""
+
+import os
+import tempfile
+
+import helpers.hdbg as hdbg
+import helpers.hio as hio
+import helpers.hsystem as hsystem
+import helpers.lib_tasks.lib_tasks_pytest as hltltapy
+import helpers.test.test_case as hvtc
+
+
+class TestPytestRunClass(hvtc.TestCase):
+    """Tests for pytest_run_class task."""
+
+    def test_find_existing_class(self) -> None:
+        """Test that pytest_run_class finds an existing class."""
+        # Create a temporary test file.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_file = os.path.join(tmpdir, "test_example.py")
+            hio.to_file(
+                test_file,
+                'import unittest\n\nclass TestExample1(unittest.TestCase):\n    def test_one(self):\n        pass\n',
+            )
+            # Create a test dir structure.
+            test_dir = os.path.join(tmpdir, "test")
+            os.makedirs(test_dir)
+            hio.to_file(
+                os.path.join(test_dir, "__init__.py"),
+                "",
+            )
+            hio.to_file(
+                os.path.join(test_dir, "test_example.py"),
+                'import unittest\n\nclass TestExample1(unittest.TestCase):\n    def test_one(self):\n        pass\n',
+            )
+            # Find the class.
+            import helpers.lib_tasks.lib_tasks_find as hltlafin
+
+            file_names = hltlafin._find_test_files(test_dir)
+            result = hltlafin._find_test_class("TestExample1", file_names, exact_match=True)
+            self.assertLen(result, 1)
+            self.assertIn("TestExample1", result[0])
+
+    def test_find_nonexistent_class(self) -> None:
+        """Test that pytest_run_class handles missing class."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_dir = os.path.join(tmpdir, "test")
+            os.makedirs(test_dir)
+            hio.to_file(
+                os.path.join(test_dir, "__init__.py"),
+                "",
+            )
+            hio.to_file(
+                os.path.join(test_dir, "test_example.py"),
+                'import unittest\n\nclass TestExample1(unittest.TestCase):\n    def test_one(self):\n        pass\n',
+            )
+            import helpers.lib_tasks.lib_tasks_find as hltlafin
+
+            file_names = hltlafin._find_test_files(test_dir)
+            result = hltlafin._find_test_class(
+                "TestNonexistent", file_names, exact_match=True
+            )
+            self.assertLen(result, 0)
+
+    def test_ambiguous_class(self) -> None:
+        """Test that pytest_run_class handles ambiguous class names."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_dir = os.path.join(tmpdir, "test")
+            os.makedirs(test_dir)
+            hio.to_file(
+                os.path.join(test_dir, "__init__.py"),
+                "",
+            )
+            hio.to_file(
+                os.path.join(test_dir, "test_example.py"),
+                'import unittest\n\nclass TestExample1(unittest.TestCase):\n    def test_one(self):\n        pass\n\nclass TestExample2(unittest.TestCase):\n    def test_two(self):\n        pass\n',
+            )
+            import helpers.lib_tasks.lib_tasks_find as hltlafin
+
+            file_names = hltlafin._find_test_files(test_dir)
+            # Non-exact match should find both.
+            result = hltlafin._find_test_class("TestExample", file_names, exact_match=False)
+            self.assertLen(result, 2)


### PR DESCRIPTION
## Summary

Adds `pytest_run_class` invoke task to run a specific test class by name.

## Changes

- Added `pytest_run_class` task to `lib_tasks_pytest.py`
- Uses existing `_find_test_class` from `lib_tasks_find.py` for class discovery
- Supports exact class matching to avoid ambiguity
- Added `preview` mode to print command without executing
- Added tests for finding existing, nonexistent, and ambiguous classes

## Usage

```bash
# Run a specific test class
invoke pytest_run_class --class-name TestExample1

# Preview the command without executing
invoke pytest_run_class --class-name TestExample1 --preview

# Search from a specific directory
invoke pytest_run_class --class-name TestExample1 --dir-name helpers/test
```

## Testing

- Added `test_lib_tasks_pytest.py` with tests for:
  - Finding existing test classes
  - Handling nonexistent classes
  - Handling ambiguous class names

Refs: #1388