### PR TITLE
HelpersTask1388_Implement_targeted_pytest_run_class

### DIFF
--- a/helpers/lib_tasks/__init__.py
+++ b/helpers/lib_tasks/__init__.py
@@ -23,6 +23,7 @@ from .lib_tasks_lint import *  # isort:skip  # noqa: F401,F403 # pylint: disable
 from .lib_tasks_perms import *  # isort:skip  # noqa: F401,F403 # pylint: disable=unused-import,unused-wildcard-import,wildcard-import
 from .lib_tasks_print import *  # isort:skip  # noqa: F401,F403 # pylint: disable=unused-import,unused-wildcard-import,wildcard-import
 from .lib_tasks_pytest import *  # isort:skip  # noqa: F401,F403 # pylint: disable=unused-import,unused-wildcard-import,wildcard-import
+from .lib_tasks_pytest_run import *  # isort:skip  # noqa: F401,F403 # pylint: disable=unused-import,unused-wildcard-import,wildcard-import
 from .lib_tasks_utils import *  # isort:skip  # noqa: F401,F403 # pylint: disable=unused-import,unused-wildcard-import,wildcard-import
 
 _LOG = logging.getLogger(__name__)

--- a/helpers/lib_tasks/lib_tasks_find.py
+++ b/helpers/lib_tasks/lib_tasks_find.py
@@ -1,7 +1,7 @@
 """
 Import as:
 
-import helpers.lib_tasks.lib_tasks_find as hlitafin
+import helpers.lib_tasks.lib_tasks_find as hltltafi
 """
 
 import functools
@@ -11,7 +11,7 @@ import os
 import re
 from typing import Iterator, List, Optional, Tuple
 
-from invoke import task
+from invoke.tasks import task
 
 # We want to minimize the dependencies from non-standard Python packages since
 # this code needs to run with minimal dependencies and without Docker.
@@ -20,6 +20,7 @@ import helpers.hio as hio
 import helpers.hlist as hlist
 import helpers.hprint as hprint
 import helpers.hsystem as hsystem
+import helpers.lib_tasks.lib_tasks_find_class as hltltficl
 import helpers.lib_tasks.lib_tasks_utils as hlitauti
 
 _LOG = logging.getLogger(__name__)
@@ -34,9 +35,7 @@ _LOG = logging.getLogger(__name__)
 def _find_test_files(
     dir_name: Optional[str] = None, use_absolute_path: bool = False
 ) -> List[str]:
-    """
-    Find all the files containing test code in `abs_dir`.
-    """
+    """Find all the files containing test code in `abs_dir`."""
     dir_name = dir_name or "."
     hdbg.dassert_dir_exists(dir_name)
     _LOG.debug("abs_dir=%s", dir_name)
@@ -89,8 +88,7 @@ def _find_test_files(
 def _find_test_class(
     class_name: str, file_names: List[str], exact_match: bool = False
 ) -> List[str]:
-    """
-    Find test file containing `class_name` and report it in pytest format.
+    """Find matching class declarations and report qualified pytest node IDs.
 
     E.g., for "TestLibTasksRunTests1" return
     "test/test_lib_tasks.py::TestLibTasksRunTests1"
@@ -98,33 +96,7 @@ def _find_test_class(
     :param exact_match: find an exact match or an approximate where `class_name`
         is included in the class name
     """
-    # > jackpy TestLibTasksRunTests1
-    # test/test_lib_tasks.py:60:class TestLibTasksRunTests1(hut.TestCase):
-    regex = r"^\s*class\s+(\S+)\s*\("
-    _LOG.debug("regex='%s'", regex)
-    res: List[str] = []
-    # Scan all the files.
-    for file_name in file_names:
-        _LOG.debug("file_name=%s", file_name)
-        txt = hio.from_file(file_name)
-        # Search for the class in each file.
-        for i, line in enumerate(txt.split("\n")):
-            # _LOG.debug("file_name=%s i=%s: %s", file_name, i, line)
-            # TODO(gp): We should skip ```, """, '''
-            m = re.match(regex, line)
-            if m:
-                found_class_name = m.group(1)
-                _LOG.debug("  %s:%d -> %s", line, i, found_class_name)
-                if exact_match:
-                    found = found_class_name == class_name
-                else:
-                    found = class_name in found_class_name
-                if found:
-                    res_tmp = f"{file_name}::{found_class_name}"
-                    _LOG.debug("-> res_tmp=%s", res_tmp)
-                    res.append(res_tmp)
-    res = sorted(list(set(res)))
-    return res
+    return hltltficl.find_test_classes(class_name, file_names, exact_match)
 
 
 # TODO(gp): Extend this to accept only the test method.
@@ -134,8 +106,7 @@ def _find_test_class(
 def find_test_class(
     ctx, class_name, dir_name=".", pbcopy=True, exact_match=False
 ):  # type: ignore
-    """
-    Report test files containing `class_name` in a format compatible with
+    """Report test files containing `class_name` in a format compatible with
     pytest.
 
     :param class_name: the class to search
@@ -183,8 +154,7 @@ def _scan_files(python_files: List[str]) -> Iterator:
 
 
 def _find_short_import(iterator: Iterator, short_import: str) -> _FindResults:
-    """
-    Find imports in the Python files with the given short import.
+    """Find imports in the Python files with the given short import.
 
     E.g., for dtfcodarun dataflow/core/test/test_builders.py:9:import
     dataflow.core.dag_runner as dtfcodarun returns
@@ -263,8 +233,7 @@ def _process_find_results(results: _FindResults, how: str) -> List:
 
 @task
 def find(ctx, regex, mode="all", how="remove_dups", subdir="."):  # type: ignore
-    """
-    Find symbols, imports, test classes and so on.
+    """Find symbols, imports, test classes and so on.
 
     Example:
     ```
@@ -333,10 +302,8 @@ def find(ctx, regex, mode="all", how="remove_dups", subdir="."):  # type: ignore
 def _find_test_decorator(
     decorator_name: str, file_names: List[str]
 ) -> List[str]:
-    """
-    Find test files containing tests with a certain decorator
-    `@pytest.mark.XYZ`.
-    """
+    """Find test files containing tests with a certain decorator
+    `@pytest.mark.XYZ`."""
     hdbg.dassert_isinstance(file_names, list)
     # E.g.,
     #   @pytest.mark.slow(...)
@@ -366,8 +333,7 @@ def _find_test_decorator(
 
 @task
 def find_test_decorator(ctx, decorator_name="", dir_name="."):  # type: ignore
-    """
-    Report test files containing `class_name` in pytest format.
+    """Report test files containing `class_name` in pytest format.
 
     :param decorator_name: the decorator to search
     :param dir_name: the dir from which to search
@@ -474,8 +440,7 @@ def find_dependency(  # type: ignore
     ignore_helpers=True,
     remove_dups=True,
 ):
-    """
-    E.g., ```
+    """E.g., ```
 
     # Find all the dependency of a module from itself
     > i find_dependency --module-name "amp.dataflow.model" --mode "find_lev2_deps" --ignore-helpers --only-module dataflow

--- a/helpers/lib_tasks/lib_tasks_find_class.py
+++ b/helpers/lib_tasks/lib_tasks_find_class.py
@@ -1,4 +1,5 @@
-"""Parse Python class declarations for test discovery without importing
+"""
+Parse Python class declarations for test discovery without importing
 modules.
 
 Import as:
@@ -8,7 +9,7 @@ import helpers.lib_tasks.lib_tasks_find_class as hltltficl
 
 import ast
 import logging
-from typing import Iterator, List, Sequence, Tuple
+from typing import Iterator, List, Tuple
 
 import helpers.hio as hio
 
@@ -16,29 +17,39 @@ _LOG = logging.getLogger(__name__)
 
 
 def _iter_class_paths(
-    statements: Sequence[ast.stmt], parents: Tuple[str, ...] = ()
+    node: ast.AST, parents: Tuple[str, ...] = ()
 ) -> Iterator[Tuple[str, ...]]:
-    """Yield module and class-nested class paths in source order."""
-    for statement in statements:
-        if not isinstance(statement, ast.ClassDef):
-            continue
-        class_path = parents + (statement.name,)
-        yield class_path
-        # Pytest can collect nested classes, but not classes local to a
-        # function. Recurse only through class bodies to preserve that rule.
-        yield from _iter_class_paths(statement.body, class_path)
+    """
+    Yield syntactic class paths outside local function scopes.
+    """
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+        return
+    if isinstance(node, ast.ClassDef):
+        parents += (node.name,)
+        yield parents
+        # Bases and decorators cannot contain class declarations. Walking only
+        # the body also keeps every nested node under its full class ancestry.
+        children = node.body
+    else:
+        children = ast.iter_child_nodes(node)
+    for child in children:
+        yield from _iter_class_paths(child, parents)
 
 
 def find_class_paths(source: str, file_name: str) -> List[Tuple[str, ...]]:
-    """Return collectible class paths parsed from Python `source`."""
+    """
+    Return syntactic class paths parsed from Python `source`.
+    """
     module = ast.parse(source, filename=file_name)
-    return list(_iter_class_paths(module.body))
+    return list(_iter_class_paths(module))
 
 
 def find_test_classes(
     class_name: str, file_names: List[str], exact_match: bool
 ) -> List[str]:
-    """Find matching classes and return deterministic pytest node IDs."""
+    """
+    Find matching classes and return deterministic pytest node IDs.
+    """
     result = []
     for file_name in file_names:
         source = hio.from_file(file_name)

--- a/helpers/lib_tasks/lib_tasks_find_class.py
+++ b/helpers/lib_tasks/lib_tasks_find_class.py
@@ -1,0 +1,65 @@
+"""Parse Python class declarations for test discovery without importing
+modules.
+
+Import as:
+
+import helpers.lib_tasks.lib_tasks_find_class as hltltficl
+"""
+
+import ast
+import logging
+from typing import Iterator, List, Sequence, Tuple
+
+import helpers.hio as hio
+
+_LOG = logging.getLogger(__name__)
+
+
+def _iter_class_paths(
+    statements: Sequence[ast.stmt], parents: Tuple[str, ...] = ()
+) -> Iterator[Tuple[str, ...]]:
+    """Yield module and class-nested class paths in source order."""
+    for statement in statements:
+        if not isinstance(statement, ast.ClassDef):
+            continue
+        class_path = parents + (statement.name,)
+        yield class_path
+        # Pytest can collect nested classes, but not classes local to a
+        # function. Recurse only through class bodies to preserve that rule.
+        yield from _iter_class_paths(statement.body, class_path)
+
+
+def find_class_paths(source: str, file_name: str) -> List[Tuple[str, ...]]:
+    """Return collectible class paths parsed from Python `source`."""
+    module = ast.parse(source, filename=file_name)
+    return list(_iter_class_paths(module.body))
+
+
+def find_test_classes(
+    class_name: str, file_names: List[str], exact_match: bool
+) -> List[str]:
+    """Find matching classes and return deterministic pytest node IDs."""
+    result = []
+    for file_name in file_names:
+        source = hio.from_file(file_name)
+        try:
+            class_paths = find_class_paths(source, file_name)
+        except SyntaxError as error:
+            _LOG.warning(
+                "Skipping malformed Python file '%s': %s (line %s)",
+                file_name,
+                error.msg,
+                error.lineno,
+            )
+            continue
+        for class_path in class_paths:
+            found_class_name = class_path[-1]
+            matches = (
+                found_class_name == class_name
+                if exact_match
+                else class_name in found_class_name
+            )
+            if matches:
+                pytest_path = "::".join(class_path)
+                result.append(f"{file_name}::{pytest_path}")
+    return sorted(set(result))

--- a/helpers/lib_tasks/lib_tasks_pytest_run.py
+++ b/helpers/lib_tasks/lib_tasks_pytest_run.py
@@ -19,7 +19,9 @@ import helpers.lib_tasks.lib_tasks_utils as hltltaut
 def _resolve_pytest_class_target(
     class_name: str, search_root: str, run_file: bool
 ) -> str:
-    """Resolve an exact test class to one pytest target."""
+    """
+    Resolve an exact test class to one pytest target.
+    """
     if not class_name:
         raise ValueError("You need to specify a class name")
     file_names = hltltafi._find_test_files(search_root)
@@ -36,14 +38,16 @@ def _resolve_pytest_class_target(
         )
     target = targets[0]
     if run_file:
-        target = target.rsplit("::", 1)[0]
+        target = target.split("::", 1)[0]
     return target
 
 
 def _build_pytest_run_class_command(
     class_name: str, search_root: str = ".", run_file: bool = False
 ) -> str:
-    """Build a safely quoted command for one test class or its file."""
+    """
+    Build a safely quoted command for one test class or its file.
+    """
     target = _resolve_pytest_class_target(class_name, search_root, run_file)
     return f"pytest {shlex.quote(target)}"
 
@@ -63,9 +67,9 @@ def pytest_run_class(
     > invoke pytest_run_class -c TestExample
     > invoke pytest_run_class -c TestExample --run-file
     > invoke pytest_run_class -c TestExample --search-root src --preview
+    ```
 
     Supports base-less, based, and multiline classes without importing tests.
-    ```
 
     :param class_name: exact test class name to run
     :param run_file: run the whole containing file instead of only the class

--- a/helpers/lib_tasks/lib_tasks_pytest_run.py
+++ b/helpers/lib_tasks/lib_tasks_pytest_run.py
@@ -1,0 +1,89 @@
+"""
+Import as:
+
+import helpers.lib_tasks.lib_tasks_pytest_run as hltltpyru
+"""
+
+import logging
+import shlex
+
+from invoke.tasks import task
+
+import helpers.lib_tasks.lib_tasks_find as hltltafi
+import helpers.lib_tasks.lib_tasks_utils as hltltaut
+
+_LOG = logging.getLogger(__name__)
+
+
+# #############################################################################
+# Run a pytest class.
+# #############################################################################
+
+
+def _resolve_pytest_class_target(
+    class_name: str, search_root: str, run_file: bool
+) -> str:
+    """
+    Resolve an exact test class to one pytest target.
+    """
+    if not class_name:
+        raise ValueError("You need to specify a class name")
+    file_names = hltltafi._find_test_files(search_root)
+    targets = hltltafi._find_test_class(class_name, file_names, exact_match=True)
+    if not targets:
+        raise ValueError(
+            f"Could not find test class '{class_name}' under '{search_root}'"
+        )
+    if len(targets) > 1:
+        target_list = "\n".join(targets)
+        raise ValueError(
+            f"Test class '{class_name}' is ambiguous; found "
+            f"{len(targets)} matches:\n{target_list}"
+        )
+    target = targets[0]
+    if run_file:
+        target = target.rsplit("::", 1)[0]
+    return target
+
+
+def _build_pytest_run_class_command(
+    class_name: str, search_root: str = ".", run_file: bool = False
+) -> str:
+    """
+    Build a safely quoted command for one test class or its file.
+    """
+    target = _resolve_pytest_class_target(class_name, search_root, run_file)
+    return f"pytest {shlex.quote(target)}"
+
+
+@task
+def pytest_run_class(
+    ctx,
+    class_name,
+    run_file=False,
+    preview=False,
+    search_root=".",
+):  # type: ignore
+    """Run an exactly named pytest class or its containing file.
+
+    E.g.:
+    ```bash
+    > invoke pytest_run_class -c TestExample
+    > invoke pytest_run_class -c TestExample --run-file
+    > invoke pytest_run_class -c TestExample --search-root src --preview
+    ```
+
+    :param class_name: exact test class name to run
+    :param run_file: run the whole containing file instead of only the class
+    :param preview: print the command without executing it
+    :param search_root: directory in which to search for test files
+    """
+    hltltaut.report_task()
+    cmd = _build_pytest_run_class_command(
+        class_name, search_root=search_root, run_file=run_file
+    )
+    if preview:
+        _LOG.info("Preview: %s", cmd)
+        return 0
+    result = ctx.run(cmd, echo=True, warn=False)
+    return result.return_code

--- a/helpers/lib_tasks/lib_tasks_pytest_run.py
+++ b/helpers/lib_tasks/lib_tasks_pytest_run.py
@@ -4,16 +4,12 @@ Import as:
 import helpers.lib_tasks.lib_tasks_pytest_run as hltltpyru
 """
 
-import logging
 import shlex
 
 from invoke.tasks import task
 
 import helpers.lib_tasks.lib_tasks_find as hltltafi
 import helpers.lib_tasks.lib_tasks_utils as hltltaut
-
-_LOG = logging.getLogger(__name__)
-
 
 # #############################################################################
 # Run a pytest class.
@@ -83,7 +79,7 @@ def pytest_run_class(
         class_name, search_root=search_root, run_file=run_file
     )
     if preview:
-        _LOG.info("Preview: %s", cmd)
+        print(cmd)
         return 0
     result = ctx.run(cmd, echo=True, warn=False)
     return result.return_code

--- a/helpers/lib_tasks/lib_tasks_pytest_run.py
+++ b/helpers/lib_tasks/lib_tasks_pytest_run.py
@@ -19,9 +19,7 @@ import helpers.lib_tasks.lib_tasks_utils as hltltaut
 def _resolve_pytest_class_target(
     class_name: str, search_root: str, run_file: bool
 ) -> str:
-    """
-    Resolve an exact test class to one pytest target.
-    """
+    """Resolve an exact test class to one pytest target."""
     if not class_name:
         raise ValueError("You need to specify a class name")
     file_names = hltltafi._find_test_files(search_root)
@@ -45,9 +43,7 @@ def _resolve_pytest_class_target(
 def _build_pytest_run_class_command(
     class_name: str, search_root: str = ".", run_file: bool = False
 ) -> str:
-    """
-    Build a safely quoted command for one test class or its file.
-    """
+    """Build a safely quoted command for one test class or its file."""
     target = _resolve_pytest_class_target(class_name, search_root, run_file)
     return f"pytest {shlex.quote(target)}"
 
@@ -67,6 +63,8 @@ def pytest_run_class(
     > invoke pytest_run_class -c TestExample
     > invoke pytest_run_class -c TestExample --run-file
     > invoke pytest_run_class -c TestExample --search-root src --preview
+
+    Supports base-less, based, and multiline classes without importing tests.
     ```
 
     :param class_name: exact test class name to run

--- a/helpers/lib_tasks/test/test_lib_tasks_find_class.py
+++ b/helpers/lib_tasks/test/test_lib_tasks_find_class.py
@@ -1,0 +1,124 @@
+import os
+from typing import Dict, List
+
+import helpers.hprint as hprint
+import helpers.hunit_test as hunitest
+import helpers.lib_tasks.lib_tasks_find as hltltafi
+
+
+# #############################################################################
+# Test_find_test_class_ast1
+# #############################################################################
+
+
+class Test_find_test_class_ast1(hunitest.TestCase):
+    def _create_test_files(self, file_dict: Dict[str, str]) -> List[str]:
+        test_dir = os.path.join(self.get_scratch_space(), "test")
+        file_dict = {
+            file_name: hprint.dedent(source)
+            for file_name, source in file_dict.items()
+        }
+        hunitest.create_test_dir(test_dir, incremental=True, file_dict=file_dict)
+        return sorted(os.path.join(test_dir, name) for name in file_dict)
+
+    def test_plain_and_multiline_classes_are_found(self) -> None:
+        file_names = self._create_test_files(
+            {
+                "test_classes.py": """
+                    class TestPlain:
+                        pass
+
+                    class TestMultiline(
+                        object,
+                    ):
+                        pass
+                """
+            }
+        )
+        actual = hltltafi._find_test_class(
+            "Test", list(reversed(file_names)) + file_names
+        )
+        expected = [
+            f"{file_names[0]}::TestMultiline",
+            f"{file_names[0]}::TestPlain",
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_strings_and_comments_are_ignored(self) -> None:
+        file_names = self._create_test_files(
+            {
+                "test_non_code.py": '''
+                    """
+                    class TestInString(object):
+                        pass
+                    """
+                    # class TestInComment(object):
+                '''
+            }
+        )
+        self.assertEqual(hltltafi._find_test_class("Test", file_names), [])
+
+    def test_exact_and_substring_matching(self) -> None:
+        file_names = self._create_test_files(
+            {
+                "test_names.py": """
+                    class TestAlpha:
+                        pass
+
+                    class TestAlphabet:
+                        pass
+                """
+            }
+        )
+        prefix = f"{file_names[0]}::"
+        exact = hltltafi._find_test_class(
+            "TestAlpha", file_names, exact_match=True
+        )
+        substring = hltltafi._find_test_class("TestAlpha", file_names)
+        self.assertEqual(exact, [prefix + "TestAlpha"])
+        self.assertEqual(
+            substring, [prefix + "TestAlpha", prefix + "TestAlphabet"]
+        )
+
+    def test_nested_classes_are_qualified_and_function_locals_ignored(
+        self,
+    ) -> None:
+        file_names = self._create_test_files(
+            {
+                "test_nested.py": """
+                    class TestOuter:
+                        class TestInner:
+                            pass
+
+                    def make_class():
+                        class TestLocal:
+                            pass
+                """
+            }
+        )
+        prefix = f"{file_names[0]}::"
+        actual = hltltafi._find_test_class("Test", file_names)
+        expected = [prefix + "TestOuter", prefix + "TestOuter::TestInner"]
+        self.assertEqual(actual, expected)
+
+    def test_malformed_file_warns_and_valid_files_are_still_searched(
+        self,
+    ) -> None:
+        file_names = self._create_test_files(
+            {
+                "test_broken.py": "class TestBroken(\n",
+                "test_valid.py": """
+                    class TestValid:
+                        pass
+                """,
+            }
+        )
+        with self.assertLogs(
+            "helpers.lib_tasks.lib_tasks_find_class", level="WARNING"
+        ) as captured:
+            actual = hltltafi._find_test_class("TestValid", file_names)
+        self.assertEqual(actual, [f"{file_names[1]}::TestValid"])
+        warning = "\n".join(captured.output)
+        self.assertIn("Skipping malformed Python file", warning)
+        self.assertIn(file_names[0], warning)
+        self.assertIn("line 1", warning)

--- a/helpers/lib_tasks/test/test_lib_tasks_find_class.py
+++ b/helpers/lib_tasks/test/test_lib_tasks_find_class.py
@@ -86,19 +86,68 @@ class Test_find_test_class_ast1(hunitest.TestCase):
         file_names = self._create_test_files(
             {
                 "test_nested.py": """
-                    class TestOuter:
-                        class TestInner:
+                    if True:
+                        class TestConditional:
                             pass
+
+                    class TestOuter:
+                        if True:
+                            class TestInner:
+                                pass
 
                     def make_class():
                         class TestLocal:
+                            pass
+
+                    async def make_async_class():
+                        class TestAsyncLocal:
                             pass
                 """
             }
         )
         prefix = f"{file_names[0]}::"
         actual = hltltafi._find_test_class("Test", file_names)
-        expected = [prefix + "TestOuter", prefix + "TestOuter::TestInner"]
+        expected = [
+            prefix + "TestConditional",
+            prefix + "TestOuter",
+            prefix + "TestOuter::TestInner",
+        ]
+        self.assertEqual(actual, expected)
+
+    def test_classes_in_control_flow_blocks_are_found(self) -> None:
+        file_names = self._create_test_files(
+            {
+                "test_blocks.py": """
+                    try:
+                        class TestTry:
+                            pass
+                    except Exception:
+                        class TestExcept:
+                            pass
+
+                    with open(__file__):
+                        class TestWith:
+                            pass
+
+                    for value in []:
+                        class TestFor:
+                            pass
+
+                    while False:
+                        class TestWhile:
+                            pass
+                """
+            }
+        )
+        prefix = f"{file_names[0]}::"
+        actual = hltltafi._find_test_class("Test", file_names)
+        expected = [
+            prefix + "TestExcept",
+            prefix + "TestFor",
+            prefix + "TestTry",
+            prefix + "TestWhile",
+            prefix + "TestWith",
+        ]
         self.assertEqual(actual, expected)
 
     def test_malformed_file_warns_and_valid_files_are_still_searched(

--- a/helpers/lib_tasks/test/test_lib_tasks_pytest_run.py
+++ b/helpers/lib_tasks/test/test_lib_tasks_pytest_run.py
@@ -95,8 +95,14 @@ class Test_pytest_run_class1(hunitest.TestCase):
 
     def test_preview_does_not_execute(self) -> None:
         search_root = self._create_test_tree()
+        expected = hltltpyru._build_pytest_run_class_command(
+            "TestSelected", search_root=search_root
+        )
         ctx = icontext.Context()
-        with umock.patch.object(ctx, "run") as run:
+        with (
+            umock.patch.object(ctx, "run") as run,
+            umock.patch("builtins.print") as print_,
+        ):
             actual = hltltpyru.pytest_run_class(
                 ctx,
                 "TestSelected",
@@ -105,6 +111,7 @@ class Test_pytest_run_class1(hunitest.TestCase):
             )
         self.assertEqual(actual, 0)
         run.assert_not_called()
+        print_.assert_called_with(expected)
 
     def test_failure_is_propagated(self) -> None:
         search_root = self._create_test_tree()

--- a/helpers/lib_tasks/test/test_lib_tasks_pytest_run.py
+++ b/helpers/lib_tasks/test/test_lib_tasks_pytest_run.py
@@ -25,6 +25,10 @@ class Test_pytest_run_class1(hunitest.TestCase):
 
                 class TestSelectedExtra(object):
                     pass
+
+                class TestOuter:
+                    class TestInner:
+                        pass
                 """
             ),
         }
@@ -54,6 +58,14 @@ class Test_pytest_run_class1(hunitest.TestCase):
         search_root = self._create_test_tree()
         actual = hltltpyru._resolve_pytest_class_target(
             "TestSelected", search_root, run_file=True
+        )
+        expected = os.path.join(search_root, "test/test_selected.py")
+        self.assert_equal(actual, expected)
+
+    def test_nested_class_containing_file(self) -> None:
+        search_root = self._create_test_tree()
+        actual = hltltpyru._resolve_pytest_class_target(
+            "TestInner", search_root, run_file=True
         )
         expected = os.path.join(search_root, "test/test_selected.py")
         self.assert_equal(actual, expected)

--- a/helpers/lib_tasks/test/test_lib_tasks_pytest_run.py
+++ b/helpers/lib_tasks/test/test_lib_tasks_pytest_run.py
@@ -1,0 +1,118 @@
+import os
+import unittest.mock as umock
+
+import invoke.context as icontext
+import pytest
+
+import helpers.hprint as hprint
+import helpers.hunit_test as hunitest
+import helpers.lib_tasks.lib_tasks_pytest_run as hltltpyru
+
+
+# #############################################################################
+# Test_pytest_run_class1
+# #############################################################################
+
+
+class Test_pytest_run_class1(hunitest.TestCase):
+    def _create_test_tree(self, duplicate: bool = False) -> str:
+        search_root = os.path.join(self.get_scratch_space(), "path with spaces")
+        file_dict = {
+            "test/test_selected.py": hprint.dedent(
+                """
+                class TestSelected(object):
+                    pass
+
+                class TestSelectedExtra(object):
+                    pass
+                """
+            ),
+        }
+        if duplicate:
+            file_dict["test/test_duplicate.py"] = hprint.dedent(
+                """
+                class TestSelected(object):
+                    pass
+                """
+            )
+        hunitest.create_test_dir(
+            search_root, incremental=True, file_dict=file_dict
+        )
+        return search_root
+
+    def test_exact_class(self) -> None:
+        search_root = self._create_test_tree()
+        actual = hltltpyru._resolve_pytest_class_target(
+            "TestSelected", search_root, run_file=False
+        )
+        expected = os.path.join(
+            search_root, "test/test_selected.py::TestSelected"
+        )
+        self.assert_equal(actual, expected)
+
+    def test_containing_file(self) -> None:
+        search_root = self._create_test_tree()
+        actual = hltltpyru._resolve_pytest_class_target(
+            "TestSelected", search_root, run_file=True
+        )
+        expected = os.path.join(search_root, "test/test_selected.py")
+        self.assert_equal(actual, expected)
+
+    def test_no_match(self) -> None:
+        search_root = self._create_test_tree()
+        ctx = icontext.Context()
+        with umock.patch.object(ctx, "run") as run:
+            with pytest.raises(ValueError, match="Could not find test class"):
+                hltltpyru.pytest_run_class(
+                    ctx, "TestMissing", search_root=search_root
+                )
+        run.assert_not_called()
+
+    def test_empty_class_name(self) -> None:
+        with pytest.raises(ValueError, match="specify a class name"):
+            hltltpyru._resolve_pytest_class_target(
+                "", self.get_scratch_space(), run_file=False
+            )
+
+    def test_ambiguous_match(self) -> None:
+        search_root = self._create_test_tree(duplicate=True)
+        ctx = icontext.Context()
+        with umock.patch.object(ctx, "run") as run:
+            with pytest.raises(ValueError, match="ambiguous; found 2 matches"):
+                hltltpyru.pytest_run_class(
+                    ctx, "TestSelected", search_root=search_root
+                )
+        run.assert_not_called()
+
+    def test_safe_path_quoting(self) -> None:
+        search_root = self._create_test_tree()
+        actual = hltltpyru._build_pytest_run_class_command(
+            "TestSelected", search_root=search_root
+        )
+        target = os.path.join(search_root, "test/test_selected.py::TestSelected")
+        expected = f"pytest '{target}'"
+        self.assert_equal(actual, expected)
+
+    def test_preview_does_not_execute(self) -> None:
+        search_root = self._create_test_tree()
+        ctx = icontext.Context()
+        with umock.patch.object(ctx, "run") as run:
+            actual = hltltpyru.pytest_run_class(
+                ctx,
+                "TestSelected",
+                preview=True,
+                search_root=search_root,
+            )
+        self.assertEqual(actual, 0)
+        run.assert_not_called()
+
+    def test_failure_is_propagated(self) -> None:
+        search_root = self._create_test_tree()
+        ctx = icontext.Context()
+        with umock.patch.object(
+            ctx, "run", side_effect=RuntimeError("pytest failed")
+        ):
+            with pytest.raises(RuntimeError, match="pytest failed"):
+                hltltpyru.pytest_run_class(
+                    ctx, "TestSelected", search_root=search_root
+                )

--- a/helpers/lib_tasks/test/test_lib_tasks_pytest_run_integration.py
+++ b/helpers/lib_tasks/test/test_lib_tasks_pytest_run_integration.py
@@ -21,7 +21,7 @@ class Test_pytest_run_class_integration1(hunitest.TestCase):
         file_dict = {
             "test/test_selected.py": hprint.dedent(
                 """
-                class TestSelected(object):
+                class TestSelected:
                     def test_passes(self):
                         assert True
 
@@ -35,6 +35,11 @@ class Test_pytest_run_class_integration1(hunitest.TestCase):
 
                 class TestNoTests(object):
                     pass
+
+                class TestOuter:
+                    class TestInner:
+                        def test_passes(self):
+                            assert True
                 """
             ),
             "test/test_unrelated.py": hprint.dedent(
@@ -65,6 +70,15 @@ class Test_pytest_run_class_integration1(hunitest.TestCase):
         self.assertEqual(rc, 0)
         self.assertIn("1 passed", output)
         self.assertNotIn("sibling executed", output)
+        self.assertNotIn("unrelated module collected", output)
+
+    def test_registered_task_runs_nested_class(self) -> None:
+        search_root = self._create_test_tree()
+        quoted_root = shlex.quote(search_root)
+        args = f"pytest_run_class -c TestInner --search-root {quoted_root}"
+        rc, output = self._run_invoke(args)
+        self.assertEqual(rc, 0)
+        self.assertIn("1 passed", output)
         self.assertNotIn("unrelated module collected", output)
 
     def test_registered_task_previews_without_execution(self) -> None:

--- a/helpers/lib_tasks/test/test_lib_tasks_pytest_run_integration.py
+++ b/helpers/lib_tasks/test/test_lib_tasks_pytest_run_integration.py
@@ -37,9 +37,10 @@ class Test_pytest_run_class_integration1(hunitest.TestCase):
                     pass
 
                 class TestOuter:
-                    class TestInner:
-                        def test_passes(self):
-                            assert True
+                    if True:
+                        class TestInner:
+                            def test_passes(self):
+                                assert True
                 """
             ),
             "test/test_unrelated.py": hprint.dedent(

--- a/helpers/lib_tasks/test/test_lib_tasks_pytest_run_integration.py
+++ b/helpers/lib_tasks/test/test_lib_tasks_pytest_run_integration.py
@@ -57,7 +57,7 @@ class Test_pytest_run_class_integration1(hunitest.TestCase):
         )
         return hsystem.system_to_string(cmd, abort_on_error=False)
 
-    def test_registered_task_targets_only_selected_nodes(self) -> None:
+    def test_registered_task_runs_only_selected_class(self) -> None:
         search_root = self._create_test_tree()
         quoted_root = shlex.quote(search_root)
         args = f"pytest_run_class -c TestSelected --search-root {quoted_root}"
@@ -66,7 +66,10 @@ class Test_pytest_run_class_integration1(hunitest.TestCase):
         self.assertIn("1 passed", output)
         self.assertNotIn("sibling executed", output)
         self.assertNotIn("unrelated module collected", output)
-        # Preview a failing class to prove that pytest is not launched.
+
+    def test_registered_task_previews_without_execution(self) -> None:
+        search_root = self._create_test_tree()
+        quoted_root = shlex.quote(search_root)
         args = (
             "pytest_run_class -c TestPreview --preview "
             f"--search-root {quoted_root}"
@@ -80,8 +83,10 @@ class Test_pytest_run_class_integration1(hunitest.TestCase):
         self.assertIn(expected, output.splitlines())
         self.assertNotIn("preview executed", output)
         self.assertNotIn("1 failed", output)
-        # File mode should fail with pytest's exact exit code even when Invoke
-        # is configured to warn, while still excluding the unrelated file.
+
+    def test_registered_task_propagates_containing_file_failure(self) -> None:
+        search_root = self._create_test_tree()
+        quoted_root = shlex.quote(search_root)
         args = (
             "--warn-only pytest_run_class -c TestSelected --run-file "
             f"--search-root {quoted_root}"
@@ -90,7 +95,10 @@ class Test_pytest_run_class_integration1(hunitest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("sibling executed", output)
         self.assertNotIn("unrelated module collected", output)
-        # Pytest uses exit code 5 when the selected node has no tests.
+
+    def test_registered_task_propagates_no_tests_exit(self) -> None:
+        search_root = self._create_test_tree()
+        quoted_root = shlex.quote(search_root)
         args = (
             "--warn-only pytest_run_class -c TestNoTests "
             f"--search-root {quoted_root}"

--- a/helpers/lib_tasks/test/test_lib_tasks_pytest_run_integration.py
+++ b/helpers/lib_tasks/test/test_lib_tasks_pytest_run_integration.py
@@ -1,0 +1,90 @@
+import os
+import shlex
+import sys
+from typing import Tuple
+
+import helpers.hprint as hprint
+import helpers.hsystem as hsystem
+import helpers.hunit_test as hunitest
+
+
+# #############################################################################
+# Test_pytest_run_class_integration1
+# #############################################################################
+
+
+class Test_pytest_run_class_integration1(hunitest.TestCase):
+    def _create_test_tree(self) -> str:
+        search_root = os.path.join(self.get_scratch_space(), "path with spaces")
+        file_dict = {
+            "test/test_selected.py": hprint.dedent(
+                """
+                class TestSelected(object):
+                    def test_passes(self):
+                        assert True
+
+                class TestSibling(object):
+                    def test_fails(self):
+                        raise AssertionError("sibling executed")
+
+                class TestPreview(object):
+                    def test_must_not_run(self):
+                        raise AssertionError("preview executed")
+                """
+            ),
+            "test/test_unrelated.py": hprint.dedent(
+                """
+                raise RuntimeError("unrelated module collected")
+                """
+            ),
+        }
+        hunitest.create_test_dir(
+            search_root, incremental=True, file_dict=file_dict
+        )
+        return search_root
+
+    def _run_invoke(self, args: str) -> Tuple[int, str]:
+        python_dir = os.path.dirname(sys.executable)
+        cmd = (
+            f"PATH={shlex.quote(python_dir)}:$PATH "
+            "CSFY_ECR_BASE_PATH=unused "
+            f"{shlex.quote(sys.executable)} -m invoke {args}"
+        )
+        return hsystem.system_to_string(cmd, abort_on_error=False)
+
+    def test_registered_task_targets_only_selected_nodes(self) -> None:
+        search_root = self._create_test_tree()
+        quoted_root = shlex.quote(search_root)
+        args = f"pytest_run_class -c TestSelected --search-root {quoted_root}"
+        rc, output = self._run_invoke(args)
+        self.assertEqual(rc, 0)
+        self.assertIn("1 passed", output)
+        self.assertNotIn("sibling executed", output)
+        self.assertNotIn("unrelated module collected", output)
+        # Preview a failing class to prove that pytest is not launched.
+        args = (
+            "pytest_run_class -c TestPreview --preview "
+            f"--search-root {quoted_root}"
+        )
+        rc, output = self._run_invoke(args)
+        self.assertEqual(rc, 0)
+        self.assertIn("pytest ", output)
+        self.assertNotIn("preview executed", output)
+        self.assertNotIn("1 failed", output)
+        # File mode should collect the sibling classes, but not another file.
+        args = (
+            "pytest_run_class -c TestSelected --run-file "
+            f"--search-root {quoted_root}"
+        )
+        rc, output = self._run_invoke(args)
+        self.assertNotEqual(rc, 0)
+        self.assertIn("sibling executed", output)
+        self.assertNotIn("unrelated module collected", output)
+
+    def test_cli_help(self) -> None:
+        rc, output = self._run_invoke("--help pytest_run_class")
+        self.assertEqual(rc, 0)
+        self.assertIn("-c STRING, --class-name=STRING", output)
+        self.assertIn("--preview", output)
+        self.assertIn("--run-file", output)
+        self.assertIn("--search-root=STRING", output)

--- a/helpers/lib_tasks/test/test_lib_tasks_pytest_run_integration.py
+++ b/helpers/lib_tasks/test/test_lib_tasks_pytest_run_integration.py
@@ -82,6 +82,18 @@ class Test_pytest_run_class_integration1(hunitest.TestCase):
         self.assertIn("1 passed", output)
         self.assertNotIn("unrelated module collected", output)
 
+    def test_registered_task_runs_nested_class_containing_file(self) -> None:
+        search_root = self._create_test_tree()
+        quoted_root = shlex.quote(search_root)
+        args = (
+            "--warn-only pytest_run_class -c TestInner --run-file "
+            f"--search-root {quoted_root}"
+        )
+        rc, output = self._run_invoke(args)
+        self.assertEqual(rc, 1)
+        self.assertIn("sibling executed", output)
+        self.assertNotIn("unrelated module collected", output)
+
     def test_registered_task_previews_without_execution(self) -> None:
         search_root = self._create_test_tree()
         quoted_root = shlex.quote(search_root)

--- a/helpers/lib_tasks/test/test_lib_tasks_pytest_run_integration.py
+++ b/helpers/lib_tasks/test/test_lib_tasks_pytest_run_integration.py
@@ -15,7 +15,9 @@ import helpers.hunit_test as hunitest
 
 class Test_pytest_run_class_integration1(hunitest.TestCase):
     def _create_test_tree(self) -> str:
-        search_root = os.path.join(self.get_scratch_space(), "path with spaces")
+        search_root = os.path.join(
+            self.get_scratch_space(), "path with spaces 'quote $dollar"
+        )
         file_dict = {
             "test/test_selected.py": hprint.dedent(
                 """
@@ -30,6 +32,9 @@ class Test_pytest_run_class_integration1(hunitest.TestCase):
                 class TestPreview(object):
                     def test_must_not_run(self):
                         raise AssertionError("preview executed")
+
+                class TestNoTests(object):
+                    pass
                 """
             ),
             "test/test_unrelated.py": hprint.dedent(
@@ -68,17 +73,31 @@ class Test_pytest_run_class_integration1(hunitest.TestCase):
         )
         rc, output = self._run_invoke(args)
         self.assertEqual(rc, 0)
-        self.assertIn("pytest ", output)
+        preview_target = os.path.join(
+            search_root, "test/test_selected.py::TestPreview"
+        )
+        expected = f"pytest {shlex.quote(preview_target)}"
+        self.assertIn(expected, output.splitlines())
         self.assertNotIn("preview executed", output)
         self.assertNotIn("1 failed", output)
-        # File mode should collect the sibling classes, but not another file.
+        # File mode should fail with pytest's exact exit code even when Invoke
+        # is configured to warn, while still excluding the unrelated file.
         args = (
-            "pytest_run_class -c TestSelected --run-file "
+            "--warn-only pytest_run_class -c TestSelected --run-file "
             f"--search-root {quoted_root}"
         )
         rc, output = self._run_invoke(args)
-        self.assertNotEqual(rc, 0)
+        self.assertEqual(rc, 1)
         self.assertIn("sibling executed", output)
+        self.assertNotIn("unrelated module collected", output)
+        # Pytest uses exit code 5 when the selected node has no tests.
+        args = (
+            "--warn-only pytest_run_class -c TestNoTests "
+            f"--search-root {quoted_root}"
+        )
+        rc, output = self._run_invoke(args)
+        self.assertEqual(rc, 5)
+        self.assertIn("no tests ran", output)
         self.assertNotIn("unrelated module collected", output)
 
     def test_cli_help(self) -> None:

--- a/tasks.py
+++ b/tasks.py
@@ -120,6 +120,7 @@ from helpers.lib_tasks import (  # isort: skip # noqa: F401  # pylint: disable=u
     pytest_find_unused_goldens,
     pytest_rename_test,
     pytest_repro,
+    pytest_run_class,
     run_blank_tests,
     run_coverage_report,
     run_coverage,


### PR DESCRIPTION
## Change

`pytest -k CLASS_NAME` collects the entire repository before selecting tests. This adds `invoke pytest_run_class -c CLASS_NAME`, which resolves an exact class to one pytest node before execution. Missing or ambiguous matches fail before running anything; there is no full-suite fallback.

The task supports `--run-file`, `--search-root`, and deterministic `--preview` output. Paths are shell-quoted, and pytest exit codes are preserved even with Invoke's `--warn-only`. It uses the current environment and does not implicitly start Docker.

The shared class finder now parses Python syntax without importing test modules. It recognizes base-less, parenthesized, multiline and nested classes, including declarations in module/class control-flow blocks; nested paths retain their full ancestry. Strings, comments and function-local classes are excluded. Malformed files produce a warning while other files remain searchable. Discovery is static: pytest still decides runtime eligibility, and dynamically constructed classes are outside its scope.

Implementation is split into focused sibling modules and registered through the existing task exports. `--run-file` selects the entire containing file, including when the chosen class is nested. Usage examples are in the task documentation.

Related issue: #1388. This implements the advertised pytest_run_class task and overlaps with #1381 and #1383; no assignment or bounty award is assumed.

## Validation

Independently reran the committed change in a separate checkout:

```bash
CSFY_ECR_BASE_PATH=causify PATH=".venv/bin:$PATH" python -m pytest \
  helpers/lib_tasks/test/test_lib_tasks_find.py \
  helpers/lib_tasks/test/test_lib_tasks_find_class.py \
  helpers/lib_tasks/test/test_lib_tasks_pytest.py \
  helpers/lib_tasks/test/test_lib_tasks_pytest_run.py \
  helpers/lib_tasks/test/test_lib_tasks_pytest_run_integration.py -q
```

**61 passed, 2 existing AMP-only skips** on Python 3.9.6 at `9180f356d6b7add899cd02bf29455dca25072441`. The existing skips are marked “Only run in amp.” Real Invoke/pytest subprocess tests cover selected classes, conditional nested classes, complete-file execution, preview without execution, paths with spaces/apostrophes/`$`, exact exit codes 1 and 5, and an unrelated module that raises during import to prove it is not collected.

Affected-file pre-commit hooks and repository Pyright passed. The aggregate lint wrapper stops in the import normalizer on duplicate import examples in the legacy finder's docstrings; the same normalizer failure was independently reproduced on pristine upstream `f1704df8`. No assertions, examples or lint thresholds were removed to hide it. The full repository suite and Docker environment were not run locally.

Developed with OpenAI Codex through CodeGraph, then independently reviewed and tested. A [complimentary technical audit](https://github.com/causify-ai/helpers/pull/1391#issuecomment-5608050782) records two reproduced findings on the pinned upstream revision; this PR addresses the class-discovery finding.
