### PR TITLE
Use get_docker_mount_context in dockerized helper scripts

### DIFF
--- a/dev_scripts_helpers/dockerize/lib_graphviz.py
+++ b/dev_scripts_helpers/dockerize/lib_graphviz.py
@@ -101,31 +101,9 @@ def run_dockerized_graphviz(
         force_rebuild=force_rebuild, use_sudo=use_sudo
     )
     # Convert files to Docker paths.
-    (
-        is_caller_host,
-        use_sibling_container_for_callee,
-        caller_mount_path,
-        callee_mount_path,
-        mount,
-    ) = hdocker.get_docker_mount_context()
-    in_file_path = hdocker.convert_caller_to_callee_docker_path(
-        in_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
-    out_file_path = hdocker.convert_caller_to_callee_docker_path(
-        out_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    mount_ctx = hdocker.get_docker_mount_context()
+    in_file_path = mount_ctx.convert_path(in_file_path)
+    out_file_path = mount_ctx.convert_path(out_file_path, is_input=False)
     # Build graphviz command.
     cmd_opts_str = " ".join(cmd_opts)
     graphviz_cmd = [
@@ -140,8 +118,8 @@ def run_dockerized_graphviz(
     # Build Docker command.
     ret = hdocker.build_and_run_docker_cmd(
         use_sudo,
-        callee_mount_path,
-        mount,
+        mount_ctx.callee_mount_path,
+        mount_ctx.mount,
         container_image,
         _DOCKERFILE,
         graphviz_cmd,

--- a/dev_scripts_helpers/dockerize/lib_latex.py
+++ b/dev_scripts_helpers/dockerize/lib_latex.py
@@ -242,46 +242,16 @@ def run_dockerized_latex(
         force_rebuild=force_rebuild, use_sudo=use_sudo
     )
     # Convert files to Docker.
-    (
-        is_caller_host,
-        use_sibling_container_for_callee,
-        caller_mount_path,
-        callee_mount_path,
-        mount,
-    ) = hdocker.get_docker_mount_context()
+    mount_ctx = hdocker.get_docker_mount_context()
     # Convert command to arguments.
     param_dict = convert_latex_cmd_to_arguments(cmd)
-    param_dict["input"] = hdocker.convert_caller_to_callee_docker_path(
-        param_dict["input"],
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    param_dict["input"] = mount_ctx.convert_path(param_dict["input"])
     key = "output-directory"
     value = param_dict[key]
-    param_dict[key] = hdocker.convert_caller_to_callee_docker_path(
-        value,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=False,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    param_dict[key] = mount_ctx.convert_path(value, check_if_exists=False, is_input=False)
     for key, value in param_dict["in_dir_params"].items():
         if value:
-            value_tmp = hdocker.convert_caller_to_callee_docker_path(
-                value,
-                caller_mount_path,
-                callee_mount_path,
-                check_if_exists=True,
-                is_input=True,
-                is_caller_host=is_caller_host,
-                use_sibling_container_for_callee=use_sibling_container_for_callee,
-            )
+            value_tmp = mount_ctx.convert_path(value)
         else:
             value_tmp = value
         param_dict["in_dir_params"][key] = value_tmp
@@ -292,8 +262,8 @@ def run_dockerized_latex(
     # Build Docker command.
     ret = hdocker.build_and_run_docker_cmd(
         use_sudo,
-        callee_mount_path,
-        mount,
+        mount_ctx.callee_mount_path,
+        mount_ctx.mount,
         container_image,
         _DOCKERFILE,
         latex_cmd,
@@ -329,22 +299,8 @@ def run_dockerized_bibtex(
         force_rebuild=force_rebuild, use_sudo=use_sudo
     )
     # Convert the `.aux` file path to its Docker path.
-    (
-        is_caller_host,
-        use_sibling_container_for_callee,
-        caller_mount_path,
-        callee_mount_path,
-        mount,
-    ) = hdocker.get_docker_mount_context()
-    docker_in_file_path = hdocker.convert_caller_to_callee_docker_path(
-        in_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    mount_ctx = hdocker.get_docker_mount_context()
+    docker_in_file_path = mount_ctx.convert_path(in_file_path)
     # Build the `bibtex` command.
     docker_dir_name = os.path.dirname(docker_in_file_path)
     base_name = os.path.splitext(os.path.basename(docker_in_file_path))[0]
@@ -352,8 +308,8 @@ def run_dockerized_bibtex(
     _LOG.debug("> %s", bibtex_cmd)
     ret = hdocker.build_and_run_docker_cmd(
         use_sudo,
-        callee_mount_path,
-        mount,
+        mount_ctx.callee_mount_path,
+        mount_ctx.mount,
         container_image,
         _DOCKERFILE,
         bibtex_cmd,

--- a/dev_scripts_helpers/dockerize/lib_markdown_toc.py
+++ b/dev_scripts_helpers/dockerize/lib_markdown_toc.py
@@ -88,22 +88,8 @@ def run_dockerized_markdown_toc(
         force_rebuild=force_rebuild, use_sudo=use_sudo
     )
     # Convert files to Docker paths.
-    (
-        is_caller_host,
-        use_sibling_container_for_callee,
-        caller_mount_path,
-        callee_mount_path,
-        mount,
-    ) = hdocker.get_docker_mount_context()
-    in_file_path = hdocker.convert_caller_to_callee_docker_path(
-        in_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    mount_ctx = hdocker.get_docker_mount_context()
+    in_file_path = mount_ctx.convert_path(in_file_path)
     cmd_opts_as_str = " ".join(cmd_opts)
     # The command is like:
     # > docker run --rm --user $(id -u):$(id -g) \
@@ -113,8 +99,8 @@ def run_dockerized_markdown_toc(
     bash_cmd = f"/usr/local/bin/markdown-toc {cmd_opts_as_str} -i {in_file_path}"
     ret = hdocker.build_and_run_docker_cmd(
         use_sudo,
-        callee_mount_path,
-        mount,
+        mount_ctx.callee_mount_path,
+        mount_ctx.mount,
         container_image,
         _DOCKERFILE,
         bash_cmd,

--- a/dev_scripts_helpers/dockerize/lib_mermaid.py
+++ b/dev_scripts_helpers/dockerize/lib_mermaid.py
@@ -153,42 +153,12 @@ def run_dockerized_mermaid(
         force_rebuild=force_rebuild, use_sudo=use_sudo
     )
     # Convert files to Docker paths.
-    (
-        is_caller_host,
-        use_sibling_container_for_callee,
-        caller_mount_path,
-        callee_mount_path,
-        mount,
-    ) = hdocker.get_docker_mount_context()
-    in_file_path = hdocker.convert_caller_to_callee_docker_path(
-        in_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
-    out_file_path = hdocker.convert_caller_to_callee_docker_path(
-        out_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    mount_ctx = hdocker.get_docker_mount_context()
+    in_file_path = mount_ctx.convert_path(in_file_path)
+    out_file_path = mount_ctx.convert_path(out_file_path, is_input=False)
     # Find puppeteerConfig.json dynamically
     puppeteer_config_file = _find_puppeteer_config()
-    puppeteer_config_path = hdocker.convert_caller_to_callee_docker_path(
-        puppeteer_config_file,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    puppeteer_config_path = mount_ctx.convert_path(puppeteer_config_file)
     # Compute the mmdc scale factor from the target DPI.
     # Chromium's default headless DPI is 96, so `--scale` is dpi / 96.
     scale = mermaid_dpi / 96
@@ -199,8 +169,8 @@ def run_dockerized_mermaid(
     )
     hdocker.build_and_run_docker_cmd(
         use_sudo,
-        callee_mount_path,
-        mount,
+        mount_ctx.callee_mount_path,
+        mount_ctx.mount,
         container_image,
         _DOCKERFILE,
         mermaid_cmd,

--- a/dev_scripts_helpers/dockerize/lib_pandoc.py
+++ b/dev_scripts_helpers/dockerize/lib_pandoc.py
@@ -402,44 +402,14 @@ def run_dockerized_pandoc(
         raise ValueError(f"Unknown container type '{container_type}'")
     _LOG.debug("container_image=%s", container_image)
     # Convert files to Docker paths.
-    (
-        is_caller_host,
-        use_sibling_container_for_callee,
-        caller_mount_path,
-        callee_mount_path,
-        mount,
-    ) = hdocker.get_docker_mount_context()
+    mount_ctx = hdocker.get_docker_mount_context()
     # Convert command to arguments.
     param_dict = _convert_pandoc_cmd_to_arguments(cmd)
-    param_dict["input"] = hdocker.convert_caller_to_callee_docker_path(
-        param_dict["input"],
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
-    param_dict["output"] = hdocker.convert_caller_to_callee_docker_path(
-        param_dict["output"],
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=False,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    param_dict["input"] = mount_ctx.convert_path(param_dict["input"])
+    param_dict["output"] = mount_ctx.convert_path(param_dict["output"], check_if_exists=False, is_input=False)
     for key, value in param_dict["in_dir_params"].items():
         if value:
-            value_tmp = hdocker.convert_caller_to_callee_docker_path(
-                value,
-                caller_mount_path,
-                callee_mount_path,
-                check_if_exists=True,
-                is_input=True,
-                is_caller_host=is_caller_host,
-                use_sibling_container_for_callee=use_sibling_container_for_callee,
-            )
+            value_tmp = mount_ctx.convert_path(value)
         else:
             value_tmp = value
         param_dict["in_dir_params"][key] = value_tmp
@@ -455,8 +425,8 @@ def run_dockerized_pandoc(
     #     -s --toc
     ret = hdocker.build_and_run_docker_cmd(
         use_sudo,
-        callee_mount_path,
-        mount,
+        mount_ctx.callee_mount_path,
+        mount_ctx.mount,
         container_image,
         dockerfile,
         pandoc_cmd,

--- a/dev_scripts_helpers/dockerize/lib_plantum.py
+++ b/dev_scripts_helpers/dockerize/lib_plantum.py
@@ -96,36 +96,14 @@ def run_dockerized_plantuml(
         force_rebuild=force_rebuild, use_sudo=use_sudo
     )
     # Convert files to Docker paths.
-    (
-        is_caller_host,
-        use_sibling_container_for_callee,
-        caller_mount_path,
-        callee_mount_path,
-        mount,
-    ) = hdocker.get_docker_mount_context()
-    out_file_path = hdocker.convert_caller_to_callee_docker_path(
-        out_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
-    in_file_path = hdocker.convert_caller_to_callee_docker_path(
-        in_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    mount_ctx = hdocker.get_docker_mount_context()
+    out_file_path = mount_ctx.convert_path(out_file_path, is_input=False)
+    in_file_path = mount_ctx.convert_path(in_file_path)
     plantuml_cmd = f"plantuml -t{dst_ext} -o {out_file_path} {in_file_path}"
     ret = hdocker.build_and_run_docker_cmd(
         use_sudo,
-        callee_mount_path,
-        mount,
+        mount_ctx.callee_mount_path,
+        mount_ctx.mount,
         container_image,
         _DOCKERFILE,
         plantuml_cmd,

--- a/dev_scripts_helpers/dockerize/lib_png.py
+++ b/dev_scripts_helpers/dockerize/lib_png.py
@@ -99,38 +99,16 @@ def run_dockerized_imagemagick(
         force_rebuild=force_rebuild, use_sudo=use_sudo
     )
     # Convert files to Docker paths.
-    (
-        is_caller_host,
-        use_sibling_container_for_callee,
-        caller_mount_path,
-        callee_mount_path,
-        mount,
-    ) = hdocker.get_docker_mount_context()
-    in_file_path = hdocker.convert_caller_to_callee_docker_path(
-        in_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
-    out_file_path = hdocker.convert_caller_to_callee_docker_path(
-        out_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=False,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    mount_ctx = hdocker.get_docker_mount_context()
+    in_file_path = mount_ctx.convert_path(in_file_path)
+    out_file_path = mount_ctx.convert_path(out_file_path, check_if_exists=False, is_input=False)
     # Build ImageMagick command.
     cmd_opts_as_str = " ".join(cmd_opts)
     cmd = f"magick {cmd_opts_as_str} {in_file_path} {out_file_path}"
     ret = hdocker.build_and_run_docker_cmd(
         use_sudo,
-        callee_mount_path,
-        mount,
+        mount_ctx.callee_mount_path,
+        mount_ctx.mount,
         container_image,
         _DOCKERFILE,
         cmd,

--- a/dev_scripts_helpers/dockerize/lib_prettier.py
+++ b/dev_scripts_helpers/dockerize/lib_prettier.py
@@ -156,31 +156,9 @@ def run_dockerized_prettier(
     )
     dockerfile = _get_prettier_dockerfile(file_type)
     # Convert files to Docker paths.
-    (
-        is_caller_host,
-        use_sibling_container_for_callee,
-        caller_mount_path,
-        callee_mount_path,
-        mount,
-    ) = hdocker.get_docker_mount_context()
-    in_file_path = hdocker.convert_caller_to_callee_docker_path(
-        in_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
-    out_file_path = hdocker.convert_caller_to_callee_docker_path(
-        out_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=False,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    mount_ctx = hdocker.get_docker_mount_context()
+    in_file_path = mount_ctx.convert_path(in_file_path)
+    out_file_path = mount_ctx.convert_path(out_file_path, check_if_exists=False, is_input=False)
     # Our interface is (in_file, out_file) instead of the wonky prettier
     # interface based on `--write` for in place update and redirecting `stdout`
     # to save on a different place.
@@ -208,8 +186,8 @@ def run_dockerized_prettier(
     # Build the Docker command.
     ret = hdocker.build_and_run_docker_cmd(
         use_sudo,
-        callee_mount_path,
-        mount,
+        mount_ctx.callee_mount_path,
+        mount_ctx.mount,
         container_image,
         dockerfile,
         bash_cmd,

--- a/dev_scripts_helpers/dockerize/lib_svg.py
+++ b/dev_scripts_helpers/dockerize/lib_svg.py
@@ -103,31 +103,9 @@ def run_dockerized_svg_with_rsvg_convert(
         force_rebuild=force_rebuild, use_sudo=use_sudo
     )
     # Convert files to Docker paths.
-    (
-        is_caller_host,
-        use_sibling_container_for_callee,
-        caller_mount_path,
-        callee_mount_path,
-        mount,
-    ) = hdocker.get_docker_mount_context()
-    in_file_path = hdocker.convert_caller_to_callee_docker_path(
-        in_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
-    out_file_path = hdocker.convert_caller_to_callee_docker_path(
-        out_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    mount_ctx = hdocker.get_docker_mount_context()
+    in_file_path = mount_ctx.convert_path(in_file_path)
+    out_file_path = mount_ctx.convert_path(out_file_path, is_input=False)
     # Build SVG conversion command using rsvg-convert.
     # Produces high-quality output with the specified DPI.
     svg_cmd = (
@@ -137,8 +115,8 @@ def run_dockerized_svg_with_rsvg_convert(
     # Build Docker command.
     ret = hdocker.build_and_run_docker_cmd(
         use_sudo,
-        callee_mount_path,
-        mount,
+        mount_ctx.callee_mount_path,
+        mount_ctx.mount,
         container_image,
         _RSVG_CONVERT_DOCKERFILE,
         svg_cmd,
@@ -235,31 +213,9 @@ def run_dockerized_svg_with_inkscape(
         force_rebuild=force_rebuild, use_sudo=use_sudo
     )
     # Convert files to Docker paths.
-    (
-        is_caller_host,
-        use_sibling_container_for_callee,
-        caller_mount_path,
-        callee_mount_path,
-        mount,
-    ) = hdocker.get_docker_mount_context()
-    in_file_path = hdocker.convert_caller_to_callee_docker_path(
-        in_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
-    out_file_path = hdocker.convert_caller_to_callee_docker_path(
-        out_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    mount_ctx = hdocker.get_docker_mount_context()
+    in_file_path = mount_ctx.convert_path(in_file_path)
+    out_file_path = mount_ctx.convert_path(out_file_path, is_input=False)
     # Build SVG conversion command using inkscape.
     # Use --export-type for format selection.
     svg_cmd = (
@@ -269,8 +225,8 @@ def run_dockerized_svg_with_inkscape(
     # Build Docker command.
     ret = hdocker.build_and_run_docker_cmd(
         use_sudo,
-        callee_mount_path,
-        mount,
+        mount_ctx.callee_mount_path,
+        mount_ctx.mount,
         container_image,
         _INKSCAPE_DOCKERFILE,
         svg_cmd,

--- a/dev_scripts_helpers/dockerize/lib_typst.py
+++ b/dev_scripts_helpers/dockerize/lib_typst.py
@@ -208,43 +208,13 @@ def run_dockerized_typst(
         force_rebuild=force_rebuild, use_sudo=use_sudo
     )
     # Convert files to Docker paths.
-    (
-        is_caller_host,
-        use_sibling_container_for_callee,
-        caller_mount_path,
-        callee_mount_path,
-        mount,
-    ) = hdocker.get_docker_mount_context()
-    in_file_path = hdocker.convert_caller_to_callee_docker_path(
-        in_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
-    out_file_path = hdocker.convert_caller_to_callee_docker_path(
-        out_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=False,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    mount_ctx = hdocker.get_docker_mount_context()
+    in_file_path = mount_ctx.convert_path(in_file_path)
+    out_file_path = mount_ctx.convert_path(out_file_path, check_if_exists=False, is_input=False)
     # Convert the project root to a Docker path, if specified.
     root_opt = ""
     if typst_root_dir != "":
-        typst_root_dir = hdocker.convert_caller_to_callee_docker_path(
-            typst_root_dir,
-            caller_mount_path,
-            callee_mount_path,
-            check_if_exists=True,
-            is_input=True,
-            is_caller_host=is_caller_host,
-            use_sibling_container_for_callee=use_sibling_container_for_callee,
-        )
+        typst_root_dir = mount_ctx.convert_path(typst_root_dir)
         root_opt = f"--root {typst_root_dir} "
     # Build the Typst command.
     cmd_opts_as_str = " ".join(cmd_opts)
@@ -256,8 +226,8 @@ def run_dockerized_typst(
     _LOG.debug("> %s", typst_cmd)
     ret = hdocker.build_and_run_docker_cmd(
         use_sudo,
-        callee_mount_path,
-        mount,
+        mount_ctx.callee_mount_path,
+        mount_ctx.mount,
         container_image,
         TYPST_DOCKERFILE,
         typst_cmd,

--- a/dev_scripts_helpers/documentation/compress_pdf.py
+++ b/dev_scripts_helpers/documentation/compress_pdf.py
@@ -162,31 +162,9 @@ def _compress_pdf_ghostscript_dockerized(
     # `_compress_pdf_ghostscript_global()`.
     tmp_output_file = output_file + ".compressed.tmp"
     # Convert the host paths to the paths seen inside the Docker container.
-    (
-        is_caller_host,
-        use_sibling_container_for_callee,
-        caller_mount_path,
-        callee_mount_path,
-        mount,
-    ) = hdocker.get_docker_mount_context()
-    docker_input_file = hdocker.convert_caller_to_callee_docker_path(
-        input_file,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
-    docker_tmp_output_file = hdocker.convert_caller_to_callee_docker_path(
-        tmp_output_file,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    mount_ctx = hdocker.get_docker_mount_context()
+    docker_input_file = mount_ctx.convert_path(input_file)
+    docker_tmp_output_file = mount_ctx.convert_path(tmp_output_file, is_input=False)
     gs_opts = _build_gs_cmd_opts(quality)
     gs_cmd = (
         f"gs {gs_opts} -sOutputFile={docker_tmp_output_file} {docker_input_file}"
@@ -196,8 +174,8 @@ def _compress_pdf_ghostscript_dockerized(
     # gs ...`).
     hdocker.build_and_run_docker_cmd(
         use_sudo,
-        callee_mount_path,
-        mount,
+        mount_ctx.callee_mount_path,
+        mount_ctx.mount,
         _GHOSTSCRIPT_DOCKER_IMAGE,
         "",
         gs_cmd,

--- a/dev_scripts_helpers/documentation/test/test_compress_pdf.py
+++ b/dev_scripts_helpers/documentation/test/test_compress_pdf.py
@@ -171,31 +171,9 @@ class Test__compress_pdf_ghostscript_dockerized(hunitest.TestCase):
         # call: `hdocker` is our own internal wrapper, not the external
         # dependency, so it is not mocked), to build the expected `gs`
         # command.
-        (
-            is_caller_host,
-            use_sibling_container_for_callee,
-            caller_mount_path,
-            callee_mount_path,
-            _,
-        ) = dshdcpd.hdocker.get_docker_mount_context()
-        docker_input_file = dshdcpd.hdocker.convert_caller_to_callee_docker_path(
-            input_file,
-            caller_mount_path,
-            callee_mount_path,
-            check_if_exists=True,
-            is_input=True,
-            is_caller_host=is_caller_host,
-            use_sibling_container_for_callee=use_sibling_container_for_callee,
-        )
-        docker_tmp_output_file = dshdcpd.hdocker.convert_caller_to_callee_docker_path(
-            tmp_output_file,
-            caller_mount_path,
-            callee_mount_path,
-            check_if_exists=True,
-            is_input=False,
-            is_caller_host=is_caller_host,
-            use_sibling_container_for_callee=use_sibling_container_for_callee,
-        )
+        mount_ctx = dshdcpd.hdocker.get_docker_mount_context()
+        docker_input_file = mount_ctx.convert_path(input_file)
+        docker_tmp_output_file = mount_ctx.convert_path(tmp_output_file, is_input=False)
         # Prepare outputs.
         expected_cmd = (
             f"gs -sDEVICE=pdfwrite -dPDFSETTINGS={quality} "

--- a/dev_scripts_helpers/github/invite_gh_contributors.py
+++ b/dev_scripts_helpers/github/invite_gh_contributors.py
@@ -30,7 +30,6 @@ import helpers.hdocker as hdocker
 import helpers.hgit as hgit
 import helpers.hparser as hparser
 import helpers.hprint as hprint
-import helpers.hserver as hserver
 import helpers.hsystem as hsystem
 
 _LOG = logging.getLogger(__name__)
@@ -74,35 +73,15 @@ def _run_dockerized_invite(args: argparse.Namespace) -> None:  # noqa: D401
         use_sudo=args.dockerized_use_sudo,
     )
     # Mount repo and convert paths.
-    is_host = not hserver.is_inside_docker()
-    sibling = True
-    caller_mount, callee_mount, mount_str = hdocker.get_docker_mount_info(
-        is_host, sibling
-    )
+    mount_ctx = hdocker.get_docker_mount_context()
     # Locate inner script.
     inner_script_host = hsystem.find_file_in_repo(
         INNER_SCRIPT_REL, root_dir=hgit.find_git_root()
     )
-    inner_script_docker = hdocker.convert_caller_to_callee_docker_path(
-        inner_script_host,
-        caller_mount,
-        callee_mount,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_host,
-        use_sibling_container_for_callee=sibling,
-    )
+    inner_script_docker = mount_ctx.convert_path(inner_script_host)
     # Resolve helper imports.
     helpers_root_host = hgit.find_helpers_root()
-    helpers_root_docker = hdocker.convert_caller_to_callee_docker_path(
-        helpers_root_host,
-        caller_mount,
-        callee_mount,
-        check_if_exists=True,
-        is_input=False,
-        is_caller_host=is_host,
-        use_sibling_container_for_callee=sibling,
-    )
+    helpers_root_docker = mount_ctx.convert_path(helpers_root_host, is_input=False)
     # Build Flags.
     passthrough: List[str] = []
     for flag, value in vars(args).items():
@@ -113,15 +92,7 @@ def _run_dockerized_invite(args: argparse.Namespace) -> None:  # noqa: D401
         # Translate path-like args.
         if flag == "csv_file":
             csv_host = os.path.abspath(str(value))
-            csv_docker = hdocker.convert_caller_to_callee_docker_path(
-                csv_host,
-                caller_mount,
-                callee_mount,
-                check_if_exists=True,
-                is_input=True,
-                is_caller_host=is_host,
-                use_sibling_container_for_callee=sibling,
-            )
+            csv_docker = mount_ctx.convert_path(csv_host)
             passthrough.extend(["--csv_file", csv_docker])
             continue
         # Propagate flags.
@@ -136,8 +107,8 @@ def _run_dockerized_invite(args: argparse.Namespace) -> None:  # noqa: D401
         [
             "-e GITHUB_TOKEN",
             f"-e PYTHONPATH={helpers_root_docker}",
-            f"--workdir {callee_mount}",
-            f"--mount {mount_str}",
+            f"--workdir {mount_ctx.callee_mount_path}",
+            f"--mount {mount_ctx.mount}",
             container_image,
             f"{inner_script_docker} {passthrough_str}",
         ]

--- a/dev_scripts_helpers/github/sync_gh_issue_labels.py
+++ b/dev_scripts_helpers/github/sync_gh_issue_labels.py
@@ -26,7 +26,6 @@ import helpers.hdocker as hdocker
 import helpers.hgit as hgit
 import helpers.hparser as hparser
 import helpers.hprint as hprint
-import helpers.hserver as hserver
 import helpers.hsystem as hsystem
 
 _LOG = logging.getLogger(__name__)
@@ -126,43 +125,15 @@ def _run_dockerized_sync_gh_issue_labels(
         container_image, dockerfile, force_rebuild, use_sudo
     )
     # Convert file paths to Docker paths.
-    is_caller_host = not hserver.is_inside_docker()
-    use_sibling_container_for_callee = hserver.use_docker_sibling_containers()
-    caller_mount_path, callee_mount_path, mount = hdocker.get_docker_mount_info(
-        is_caller_host, use_sibling_container_for_callee
-    )
-    input_file = hdocker.convert_caller_to_callee_docker_path(
-        input_file,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    mount_ctx = hdocker.get_docker_mount_context()
+    input_file = mount_ctx.convert_path(input_file)
     helpers_root = hgit.find_helpers_root()
-    helpers_root = hdocker.convert_caller_to_callee_docker_path(
-        helpers_root,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    helpers_root = mount_ctx.convert_path(helpers_root, is_input=False)
     # Build the command.
     git_root = hgit.find_git_root()
     docker_executable = "dockerized_sync_gh_issue_labels.py"
     script = hsystem.find_file_in_repo(docker_executable, root_dir=git_root)
-    script = hdocker.convert_caller_to_callee_docker_path(
-        script,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    script = mount_ctx.convert_path(script)
     cmd = [
         script,
         f"--input_file {input_file}",
@@ -186,7 +157,7 @@ def _run_dockerized_sync_gh_issue_labels(
         [
             f"-e {token_env_var}",
             f"-e PYTHONPATH={helpers_root}",
-            f"--workdir {callee_mount_path} --mount {mount}",
+            f"--workdir {mount_ctx.callee_mount_path} --mount {mount_ctx.mount}",
             container_image,
             cmd,
         ]

--- a/dev_scripts_helpers/llms/llm_transform.py
+++ b/dev_scripts_helpers/llms/llm_transform.py
@@ -47,7 +47,6 @@ import helpers.hmarkdown as hmarkdo
 import helpers.hselect_input_output as hseinout
 import helpers.hparser as hparser
 import helpers.hprint as hprint
-import helpers.hserver as hserver
 import helpers.hsystem as hsystem
 
 _LOG = logging.getLogger(__name__)
@@ -133,53 +132,17 @@ def _run_dockerized_llm_transform(
         container_image, dockerfile, force_rebuild, use_sudo
     )
     # Convert files to Docker paths.
-    is_caller_host = not hserver.is_inside_docker()
-    use_sibling_container_for_callee = hserver.use_docker_sibling_containers()
-    caller_mount_path, callee_mount_path, mount = hdocker.get_docker_mount_info(
-        is_caller_host, use_sibling_container_for_callee
-    )
-    in_file_path = hdocker.convert_caller_to_callee_docker_path(
-        in_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
-    out_file_path = hdocker.convert_caller_to_callee_docker_path(
-        out_file_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=False,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    mount_ctx = hdocker.get_docker_mount_context()
+    in_file_path = mount_ctx.convert_path(in_file_path)
+    out_file_path = mount_ctx.convert_path(out_file_path, check_if_exists=False, is_input=False)
     helpers_root = hgit.find_helpers_root()
-    helpers_root = hdocker.convert_caller_to_callee_docker_path(
-        helpers_root,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    helpers_root = mount_ctx.convert_path(helpers_root, is_input=False)
     # Run the script inside the container.
     git_root = hgit.find_git_root()
     script = hsystem.find_file_in_repo(
         "dockerized_llm_transform.py", root_dir=git_root
     )
-    script = hdocker.convert_caller_to_callee_docker_path(
-        script,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    script = mount_ctx.convert_path(script)
     cmd_opts_as_str = " ".join(cmd_opts)
     cmd = f" {script} -i {in_file_path} -o {out_file_path} {cmd_opts_as_str}"
     docker_cmd = hdocker.get_docker_base_cmd(use_sudo)
@@ -189,8 +152,8 @@ def _run_dockerized_llm_transform(
     docker_cmd.extend(
         [
             f"-e PYTHONPATH={helpers_root}",
-            f"--workdir {callee_mount_path}",
-            f"--mount {mount}",
+            f"--workdir {mount_ctx.callee_mount_path}",
+            f"--mount {mount_ctx.mount}",
             container_image,
             cmd,
         ]

--- a/dev_scripts_helpers/notebooks/extract_notebook_images.py
+++ b/dev_scripts_helpers/notebooks/extract_notebook_images.py
@@ -25,7 +25,6 @@ import helpers.hdocker as hdocker
 import helpers.hgit as hgit
 import helpers.hparser as hparser
 import helpers.hprint as hprint
-import helpers.hserver as hserver
 import helpers.hsystem as hsystem
 
 _LOG = logging.getLogger(__name__)
@@ -169,52 +168,16 @@ def _run_dockerized_extract_notebook_images(
         container_image, dockerfile, force_rebuild, use_sudo
     )
     # Convert file paths to Docker paths.
-    is_caller_host = not hserver.is_inside_docker()
-    use_sibling_container_for_callee = hserver.use_docker_sibling_containers()
-    caller_mount_path, callee_mount_path, mount = hdocker.get_docker_mount_info(
-        is_caller_host, use_sibling_container_for_callee
-    )
-    notebook_path = hdocker.convert_caller_to_callee_docker_path(
-        notebook_path,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
-    output_dir = hdocker.convert_caller_to_callee_docker_path(
-        output_dir,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=False,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    mount_ctx = hdocker.get_docker_mount_context()
+    notebook_path = mount_ctx.convert_path(notebook_path)
+    output_dir = mount_ctx.convert_path(output_dir, check_if_exists=False, is_input=False)
     helpers_root = hgit.find_helpers_root()
-    helpers_root = hdocker.convert_caller_to_callee_docker_path(
-        helpers_root,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=False,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    helpers_root = mount_ctx.convert_path(helpers_root, is_input=False)
     # Build the command.
     git_root = hgit.find_git_root()
     docker_executable = "dockerized_extract_notebook_images.py"
     script = hsystem.find_file_in_repo(docker_executable, root_dir=git_root)
-    script = hdocker.convert_caller_to_callee_docker_path(
-        script,
-        caller_mount_path,
-        callee_mount_path,
-        check_if_exists=True,
-        is_input=True,
-        is_caller_host=is_caller_host,
-        use_sibling_container_for_callee=use_sibling_container_for_callee,
-    )
+    script = mount_ctx.convert_path(script)
     cmd = [
         script,
         f"--in_notebook_filename {notebook_path}",
@@ -231,7 +194,7 @@ def _run_dockerized_extract_notebook_images(
         [
             "-e PLAYWRIGHT_BROWSERS_PATH=/ms-playwright",
             f"-e PYTHONPATH={helpers_root}",
-            f"--workdir {callee_mount_path} --mount {mount}",
+            f"--workdir {mount_ctx.callee_mount_path} --mount {mount_ctx.mount}",
             container_image,
             cmd,
         ]

--- a/helpers/hdocker.py
+++ b/helpers/hdocker.py
@@ -11,7 +11,7 @@ import logging
 import os
 import platform
 import time
-from typing import List, Optional, Tuple
+from typing import List, NamedTuple, Optional, Tuple
 
 import helpers.hdbg as hdbg
 import helpers.henv as henv
@@ -699,6 +699,96 @@ def get_host_git_root() -> str:
     return host_git_root_path
 
 
+class DockerMountContext(NamedTuple):
+    """
+    Bundle of the Docker mount information needed to convert paths.
+
+    Returned by `get_docker_mount_context()`; it groups the five values of the
+    legacy 5-tuple and adds convenience methods (`convert_path()`,
+    `convert_io_paths()`, `convert_all_paths()`) so that callers don't have to
+    thread the mount context through every path conversion.
+
+    The NamedTuple is backward compatible: it can be unpacked positionally
+    (e.g., `a, b, c, d, e = get_docker_mount_context()`) exactly like the old
+    5-tuple.
+
+    :param is_caller_host: Whether the caller runs on the host machine or
+        inside a Docker container.
+    :param use_sibling_container_for_callee: Whether the callee runs in a
+        sibling (vs. child) container.
+    :param caller_mount_path: The mount path on the caller filesystem.
+    :param callee_mount_path: The target mount path in the callee container.
+    :param mount: The Docker mount string to pass to `docker run`.
+    """
+
+    is_caller_host: bool
+    use_sibling_container_for_callee: bool
+    caller_mount_path: str
+    callee_mount_path: str
+    mount: str
+
+    def convert_path(
+        self,
+        caller_file_path: str,
+        *,
+        check_if_exists: bool = False,
+        is_input: bool = True,
+    ) -> str:
+        """
+        Convert `caller_file_path` to its path inside the callee container.
+
+        :param caller_file_path: The file path on the caller filesystem.
+        :param check_if_exists: Whether to check if the path exists.
+        :param is_input: Whether the path is an input file (used only if
+            `check_if_exists` is True).
+        """
+        return convert_caller_to_callee_docker_path(
+            caller_file_path,
+            self.caller_mount_path,
+            self.callee_mount_path,
+            check_if_exists=check_if_exists,
+            is_input=is_input,
+            is_caller_host=self.is_caller_host,
+            use_sibling_container_for_callee=self.use_sibling_container_for_callee,
+        )
+
+    def convert_io_paths(
+        self, in_file_path: str, out_file_path: str
+    ) -> Tuple[str, str]:
+        """
+        Convert an input/output file pair to the callee container paths.
+
+        The input is checked for existence (it must be there), while the
+        output is not (it may not exist yet).
+
+        :param in_file_path: Input file path on the caller filesystem.
+        :param out_file_path: Output file path on the caller filesystem.
+        :return: Tuple of the converted `(in, out)` container paths.
+        """
+        in_callee = self.convert_path(
+            in_file_path, check_if_exists=True, is_input=True
+        )
+        out_callee = self.convert_path(
+            out_file_path, check_if_exists=False, is_input=False
+        )
+        return (in_callee, out_callee)
+
+    def convert_all_paths(self, cmd_opts: List[str]) -> List[str]:
+        """
+        Convert all the paths of a command-options list.
+
+        :param cmd_opts: List of command options (paths and flags).
+        :return: List of the converted command options.
+        """
+        return convert_all_paths_from_caller_to_callee_docker_path(
+            cmd_opts,
+            self.caller_mount_path,
+            self.callee_mount_path,
+            self.is_caller_host,
+            self.use_sibling_container_for_callee,
+        )
+
+
 def get_docker_mount_info(
     is_caller_host: bool, use_sibling_container_for_callee: bool
 ) -> Tuple[str, str, str]:
@@ -747,19 +837,26 @@ def get_docker_mount_info(
     return caller_mount_path, callee_mount_path, mount
 
 
-def get_docker_mount_context() -> Tuple[bool, bool, str, str, str]:
+def get_docker_mount_context() -> DockerMountContext:
     """
-    Return Docker mount context for container operations.
+    Return the Docker `DockerMountContext` for container operations.
 
-    :return: (is_caller_host, use_sibling_container_for_callee,
-        caller_mount_path, callee_mount_path, mount)
+    The context groups all the values needed to convert caller paths to callee
+    container paths; see the `DockerMountContext` class for the convenience
+    methods. The return type is a NamedTuple, so existing callers that unpack
+    positionally (e.g., ``a, b, c, d, e = get_docker_mount_context()``) keep
+    working unchanged.
+
+    :return: A `DockerMountContext` bundling
+        (is_caller_host, use_sibling_container_for_callee,
+        caller_mount_path, callee_mount_path, mount).
     """
     is_caller_host = not hserver.is_inside_docker()
     use_sibling_container_for_callee = hserver.use_docker_sibling_containers()
     caller_mount_path, callee_mount_path, mount = get_docker_mount_info(
         is_caller_host, use_sibling_container_for_callee
     )
-    return (
+    return DockerMountContext(
         is_caller_host,
         use_sibling_container_for_callee,
         caller_mount_path,
@@ -919,10 +1016,10 @@ def is_path(path: str) -> bool:
 
 def convert_all_paths_from_caller_to_callee_docker_path(
     cmd_opts: List[str],
-    caller_mount_path: str,
-    callee_mount_path: str,
-    is_caller_host: bool,
-    use_sibling_container_for_callee: bool,
+    caller_mount_path: Optional[str] = None,
+    callee_mount_path: Optional[str] = None,
+    is_caller_host: Optional[bool] = None,
+    use_sibling_container_for_callee: Optional[bool] = None,
 ) -> List[str]:
     """
     Convert all the paths from the caller to the callee Docker container path.
@@ -935,14 +1032,44 @@ def convert_all_paths_from_caller_to_callee_docker_path(
     - Create output dirs
     - Explicitly parse options that are outputs (e.g., `-o <file>`)
 
+    If any of the mount-context parameters are omitted (left at their default
+    ``None``), they are auto-detected via `get_docker_mount_context()`.
+
     :param cmd_opts: List of command options.
-    :param caller_mount_path: See `get_docker_mount_info()`.
-    :param callee_mount_path: See `get_docker_mount_info()`.
-    :param is_caller_host: See `get_docker_mount_info()`.
-    :param use_sibling_container_for_callee: See `get_docker_mount_info()`.
+    :param caller_mount_path: See `get_docker_mount_info()`
+        (auto-detect if None).
+    :param callee_mount_path: See `get_docker_mount_info()`
+        (auto-detect if None).
+    :param is_caller_host: See `get_docker_mount_info()`
+        (auto-detect if None).
+    :param use_sibling_container_for_callee: See `get_docker_mount_info()`
+        (auto-detect if None).
     :return: List of converted command options.
     """
     _LOG.debug(hprint.func_signature_to_str())
+    # Auto-detect mount context from the environment only when a parameter is
+    # actually omitted (keeps the common ``convert_all_paths_from_caller_to_
+    # callee_docker_path(cmd_opts)`` call cheap by avoiding `is_inside_docker()`).
+    if any(
+        p is None
+        for p in (
+            caller_mount_path,
+            callee_mount_path,
+            is_caller_host,
+            use_sibling_container_for_callee,
+        )
+    ):
+        ctx = get_docker_mount_context()
+        if caller_mount_path is None:
+            caller_mount_path = ctx.caller_mount_path
+        if callee_mount_path is None:
+            callee_mount_path = ctx.callee_mount_path
+        if is_caller_host is None:
+            is_caller_host = ctx.is_caller_host
+        if use_sibling_container_for_callee is None:
+            use_sibling_container_for_callee = (
+                ctx.use_sibling_container_for_callee
+            )
     # Converted command options.
     cmd_opts_out = []
     # Scan the list of command option.


### PR DESCRIPTION
Closes #1402.

The legacy convert_caller_to_callee_docker_path in hdocker.py has had its callers migrated over to a new API (get_docker_mount_context / DockerMountContext.convert_path). This PR swaps out the scattered boilerplate for the new context object. Previously each call site needed to pass is_caller_host / use_sibling_container_for_callee plus mount paths, so this tidies up that whole lot across ~17 files that were using the old signature.

Behavior hasn't changed - convert_path keeps the original semantics of check_if_exists and is_input, so the host->container path resolution behaves the same as before. I've also cleaned up imports that ended up not being needed anymore.

Tested on my end against the modified scripts (python3.8).